### PR TITLE
Add class config.Config (see #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-<a href="https://www.superduperdb.com"><img src="https://raw.githubusercontent.com/blythed/superduperdb/main/img/symbol_purple.png" width="150" align="right" /></a>
+<a href="https://www.superduperdb.com">
+  <img
+    src="https://raw.githubusercontent.com/superduperdb/superduperdb-stealth/img/symbol_purple.png"
+    width="150"
+    align="right"
+    />
+</a>
 
 # Welcome to SuperDuperDB!
 
@@ -55,6 +61,30 @@ If you'd like to contribute to the project we need help in many places:
 - Adding additional unittests and doctests
 - Augmenting doc-strings to make the usage patterns clearer for the uninitiated
 - Expanding the documentation, tutorials and examples
+
+## Using configs
+
+SuperDuperDB has "config variables" that can be set to customize its operation.
+
+You can see a list of their default values in this file https://github.com/SuperDuperDB/superduperdb-stealth/blob/main/default-configs.json.
+
+In the code, configs are simple data classes, defined here: https://github.com/SuperDuperDB/superduperdb-stealth/blob/main/superduperdb/misc/config.py
+
+There are three ways to set a config variable
+
+* put just the values you want to change in a file `configs.json` at the room of `superduperdb-stealth`
+* set an environment variable with the value
+* set it in code
+
+For example, these three forms are identical:
+
+* Storing `{"remote": True, "dask": {"ip": "1.1.1.1"}}` in `configs.json`
+* Setting environment variables `SUPERDUPERDB_REMOTE=true` and
+  `SUPERDUPERDB_DASK_IP=1.1.1.1`
+* In Python, `CFG.remote = True; CFG.dask.ip = '1.1.1.1'`
+
+[TBD: Secrets are just the same, except we don't even have one yet.]
+
 
 ## Use Cases
 

--- a/default-configs.json
+++ b/default-configs.json
@@ -1,0 +1,32 @@
+{
+  "apis": {},
+  "dask": {
+    "port": 8786,
+    "ip": "localhost",
+    "serializers": [],
+    "deserializers": []
+  },
+  "model_server": {
+    "port": 5001,
+    "host": "127.0.0.1"
+  },
+  "mongodb": {
+    "port": 27017,
+    "host": "localhost"
+  },
+  "notebook": {
+    "port": 8888,
+    "ip": "0.0.0.0",
+    "token": "...bad.key..."
+  },
+  "ray": {
+    "port": 0,
+    "host": "127.0.0.1",
+    "deployments": []
+  },
+  "remote": false,
+  "vector_search": {
+    "port": 5001,
+    "host": "localhost"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ transformers = "^4.29.1"
 tqdm = "^4.65.0"
 werkzeug = "^2.3.4"
 openai = "^0.27.6"
+pydantic = "^1.10.7"
+fil = "^1.1.0"
 torch = "^2.0.1"
 
 [tool.poetry.group.ci]

--- a/superduperdb/__init__.py
+++ b/superduperdb/__init__.py
@@ -1,6 +1,10 @@
 import json
 import os
+from . misc import configs
 
+__all__ = 'cf', 'CF', 'SECRET'
+
+CFG = configs.CONFIG.config
 
 try:
     with open('config.json') as f:

--- a/superduperdb/misc/config.py
+++ b/superduperdb/misc/config.py
@@ -1,0 +1,87 @@
+from pydantic import BaseModel, Field
+from superduperdb.misc import dicts
+from typing import Any, Dict, List, Optional, Union
+
+# The classes in this file define the configuration variables for SuperDuperDB.
+#
+# There is a file in the root directory named `default-config.json`
+# which has the default values for every configuration variable, serialized into JSON.
+#
+# If you change a class below, you must regenerate `default-config.json with:
+#
+#    $ python -m tests.unittests.misc.test_config
+
+_BAD_KEY = '...bad.key...'
+
+
+def _Factory(factory):
+    return Field(default_factory=factory)
+
+
+class _Model(BaseModel):
+    class Config:
+        extra = 'forbid'
+
+
+class Port(_Model):
+    port = 0
+
+
+class HostPort(Port):
+    host = 'localhost'
+
+
+class IpPort(Port):
+    ip = 'localhost'
+
+
+class Api(_Model):
+    api_key: str = Field(default=_BAD_KEY, repr=False)
+
+
+class Dask(IpPort):
+    port = 8786
+
+    serializers: List[str] = _Factory(list)
+    deserializers: List[str] = _Factory(list)
+
+
+class Deployment(_Model):
+    database = ''
+    model = ''
+
+
+class ModelServer(HostPort):
+    host = '127.0.0.1'
+    port = 5001
+
+
+class MongoDB(HostPort):
+    port = 27017
+
+
+class Notebook(IpPort):
+    port = 8888
+    ip = '0.0.0.0'
+    token: str = Field(default=_BAD_KEY, repr=False)
+
+
+class Ray(HostPort):
+    host = '127.0.0.1'
+
+    deployments: List[Deployment] = _Factory(list)
+
+
+class VectorSearch(HostPort):
+    port = 5001
+
+
+class Config(_Model):
+    apis: Dict[str, Api] = _Factory(dict)
+    dask: Dask = _Factory(Dask)
+    model_server: ModelServer = _Factory(ModelServer)
+    mongodb: MongoDB = _Factory(MongoDB)
+    notebook: Notebook = _Factory(Notebook)
+    ray: Ray = _Factory(Ray)
+    remote: bool = False
+    vector_search: VectorSearch = _Factory(VectorSearch)

--- a/superduperdb/misc/configs.py
+++ b/superduperdb/misc/configs.py
@@ -1,0 +1,38 @@
+from . import config
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from superduperdb.misc import dicts
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+import os
+
+Self = Any
+File = Union[Path, str]
+
+ROOT = Path(__file__).parents[1]
+PREFIX = 'SUPERDUPERDB_'
+FILES_NAME = 'CONFIG_FILES'
+DEFAULT_FILES = str(ROOT / 'configs.json')
+FILE_SEP = ','
+
+
+@dataclass(frozen=True)
+class ConfigSettings:
+    cls: Type
+    default_files: str
+    prefix: str
+    environ: Optional[Dict] = None
+
+    @cached_property
+    def config(self) -> Any:
+        """Read a Pydantic class"""
+        environ = dict(os.environ if self.environ is None else self.environ)
+
+        file_names = environ.pop(self.prefix + FILES_NAME, self.default_files)
+        data = dicts.read_all(file_names.split(FILE_SEP))
+        parent = self.cls().dict()
+        environ_dict = dicts.environ_to_config_dict(self.prefix, parent, environ)
+        return self.cls(**dicts.combine((*data, environ_dict)))
+
+
+CONFIG = ConfigSettings(config.Config, DEFAULT_FILES, PREFIX)

--- a/superduperdb/misc/dicts.py
+++ b/superduperdb/misc/dicts.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Sequence, TextIO, Tuple, Union
+import fil
+import os
+import sys
+
+SEP = '_'
+_NONE = object()
+
+
+def read_all(files: Sequence[Union[Path, str]], fail=False) -> Sequence[Dict]:
+    if fail:
+        return [fil.read(f) for f in files]
+    else:
+        return [fil.read(f, {}) for f in files]
+
+
+def combine(dicts: Sequence[Dict]) -> Dict:
+    result = {}
+    for d in dicts:
+        _combine_one(result, d)
+    return result
+
+
+def environ_to_config_dict(
+    prefix: str,
+    parent: Dict,
+    environ: Optional[Dict] = None,
+    err: Optional[TextIO] = sys.stderr,
+    fail: bool = False,
+):
+    env_dict = environ_dict(prefix, environ)
+
+    good, bad = _env_dict_to_config_dict(env_dict, parent)
+
+    if bad:
+        bad = {k: ', '.join([prefix + i.upper() for i in v]) for k, v in bad.items()}
+        msg = '\n'.join(f'{k}: {v}' for k, v in sorted(bad.items()))
+
+        s = 's' * (sum(len(v) for v in bad.values()) != 1)
+        msg = f'Bad environment variable{s}:\n{msg}'
+        if err is not None:
+            print(msg, file=err)
+        if fail:
+            raise ValueError(msg)
+
+    return good
+
+
+def split_address(key: str, parent: Dict) -> Iterator[Tuple[Dict, Tuple[str]]]:
+    def split(key, parent, *address):
+        if key in parent:
+            yield *address, key
+
+        for k, v in parent.items():
+            if key.startswith(ks := k + SEP) and isinstance(v, dict):
+                yield from split(key[len(ks):], v, *address, k)
+
+    return split(key, parent)
+
+
+def environ_dict(prefix: str, environ: Optional[Dict] = None) -> Dict:
+    assert prefix.isupper() and prefix.endswith(SEP) and not prefix.startswith(SEP)
+
+    d = os.environ if environ is None else environ
+    items = ((k, v) for k, v in d.items() if k.isupper() and k.startswith(prefix))
+    return {k[len(prefix):].lower(): v for k, v in items}
+
+
+def _combine_one(target, source):
+    for k, v in source.items():
+        old_v = target.get(k, _NONE)
+        if old_v is _NONE:
+            target[k] = v
+
+        elif not (isinstance(v, type(old_v)) or isinstance(old_v, type(v))):
+            err = f'Expected {type(old_v)} but got {type(v)} for key={k}'
+            raise ValueError(err)
+
+        elif isinstance(v, dict):
+            _combine_one(old_v, v)
+
+        else:
+            target[k] = v
+
+
+def _env_dict_to_config_dict(env_dict: Dict, parent: Dict) -> Dict:
+    good, bad = {}, {}
+
+    for k, v in env_dict.items():
+        addresses = list(split_address(k, parent))
+        if not addresses:
+            bad.setdefault('unknown', []).append(k)
+        elif len(addresses) > 1:
+            bad.setdefault('ambiguous', []).append(k)
+        else:
+            d = good
+            *address, last = addresses[0]
+            for a in address:
+                d = d.setdefault(a, {})
+            d[last] = v
+
+    return good, bad

--- a/tests/unittests/misc/test_config.py
+++ b/tests/unittests/misc/test_config.py
@@ -1,0 +1,169 @@
+from . test_dicts import PARENT
+from collections import Counter
+from pathlib import Path
+from pydantic import ValidationError
+from superduperdb.misc.config import _Factory, _Model, Config
+import copy
+import json
+import pytest
+
+DEFAULT_CONFIG_FILE = Path(__file__).parents[3] / 'default-configs.json'
+
+TYPE_ERROR = """
+1 validation error for Config
+dask -> port
+  value is not a valid integer (type=type_error.integer)
+"""
+NAME_ERROR = """
+1 validation error for Config
+bad_name
+  extra fields not permitted (type=value_error.extra)
+"""
+
+def test_default_config():
+    # If this test fails, try running
+    #
+    #    $ python -m tests.unittests.misc.test_config
+    #
+    # to rebuild default-configs.json
+    assert Config().dict() == json.loads(DEFAULT_CONFIG_FILE.read_text())
+
+
+def write_default_config():
+    DEFAULT_CONFIG_FILE.write_text(json.dumps(Config().dict(), indent=2))
+
+
+def test_copy_config():
+    cf = Config(**DATA)
+    assert cf.ray.deployments[0].database == 'mnist'
+
+    assert cf.dict() == DATA
+
+
+def test_type_error():
+    d2 = copy.deepcopy(DATA)
+    d2['dask']['port'] = 'bad port'
+
+    with pytest.raises(ValidationError) as pr:
+        Config(**d2)
+    assert str(pr.value).strip() == TYPE_ERROR.strip()
+
+
+def test_unknown_name():
+    with pytest.raises(ValidationError) as pr:
+        c = Config(bad_name={}, **DATA)
+    assert str(pr.value).strip() == NAME_ERROR.strip()
+
+
+def _dict_names(d, *address):
+    if isinstance(d, dict):
+        for k, v in d.items():
+            yield from _dict_names(v, *address, k)
+    else:
+        yield '_'.join(address)
+
+
+def test_dict_names():
+    actual = list(_dict_names(PARENT))
+    expected = [
+        ('red_crimson'),
+        ('red_ruby'),
+        ('blue_green_puce'),
+        ('blue_green_orange'),
+        ('blue_green_puce'),
+        ('blue_green_puce'),
+        ('blue_green_yellow'),
+        ('tan_green_orange')
+    ]
+
+    assert actual == expected
+
+
+def _dupes(cls):
+    counts = Counter(_dict_names(cls().dict()))
+    return [k for k, v in counts.items() if v > 1]
+
+
+def test_config_has_no_dupes():
+    assert _dupes(Config) == []
+
+
+def test_find_dupes():
+    class Red(_Model):
+        crimson = 'Crimson'
+        ruby = 'Ruby'
+
+    class Green(_Model):
+        puce = 'Puce'
+        orange = 'Orange'
+
+    class Blue(_Model):
+        green_puce = 'Green Puce'
+        green: Green = _Factory(Green)
+
+    class BlueGreen(_Model):
+        puce = 0
+        yellow = 30
+
+    class Green2(_Model):
+        orange = 'lime'
+
+    class Tan(_Model):
+        green: Green2 = _Factory(Green2)
+
+    class Colors(_Model):
+        red: Red = _Factory(Red)
+        blue: Blue = _Factory(Blue)
+        blue_green: BlueGreen = _Factory(BlueGreen)
+        tan: Tan = _Factory(Tan)
+
+    assert Colors().dict() == PARENT
+    assert _dupes(Colors) == ['blue_green_puce']
+
+
+DATA = {
+     'remote': False,
+     'vector_search': {
+          'host': 'localhost',
+          'port': 5001
+     },
+     'dask': {
+          'ip': 'localhost',
+          'port': 8786,
+          'serializers': ['pickle', 'dill'],
+          'deserializers': ['pickle', 'dill']
+     },
+     'ray': {
+          'deployments': [
+               {
+                    'database': 'mnist',
+                    'model': 'lenet'
+               }
+          ],
+          'host': '127.0.0.1',
+          'port': 8000
+     },
+     'model_server': {
+          'host': 'localhost',
+          'port': 5002
+     },
+     'mongodb': {
+          'host': 'localhost',
+          'port': 27017
+     },
+     'notebook': {
+          'token': '...',
+          'port': 8888,
+          'ip': '0.0.0.0'
+     },
+     'apis': {
+          'openai': {
+               'api_key': 'sk-...'
+          }
+     }
+}
+
+
+if __name__ == '__main__':
+    write_default_config()
+    print('Wrote', DEFAULT_CONFIG_FILE)

--- a/tests/unittests/misc/test_dicts.py
+++ b/tests/unittests/misc/test_dicts.py
@@ -1,0 +1,93 @@
+from superduperdb.misc import dicts
+import io
+import pytest
+
+
+def test_combine_dicts():
+    actual = dicts.combine((
+        {'one': {'two': ['three', 'four', 'five']}},
+        {'one': {'three': 3}},
+        {'four': None},
+        {'one': {'five': {'nine': 9, 'ten': 23}}},
+        {'one': {'five': {'eight': 8, 'ten': 10}}},
+    ))
+
+    expected = {
+        'one': {
+            'five': {'eight': 8, 'nine': 9, 'ten': 10},
+            'three': 3,
+            'two': ['three', 'four', 'five']
+        },
+        'four': None,
+    }
+
+    assert expected == actual
+
+
+def test_environ_dict_():
+    actual = dicts.environ_dict('TEST_', {
+        'TOAST_ONE': 'one',
+        'TEST_TWO': 'two',
+        'TEST_three': 'three',
+    })
+
+    expected = {'two': 'two'}
+    assert expected == actual
+
+
+PARENT = {
+    'red': {'crimson': 'Crimson', 'ruby': 'Ruby'},
+    'blue': {'green': {'puce': 'Puce', 'orange': 'Orange'}, 'green_puce': 'Green Puce'},
+    'blue_green': {'puce': 0, 'yellow': 30},
+    'tan': {'green': {'orange': 'lime'}},
+}
+
+
+@pytest.mark.parametrize('key, expected', (
+    ('', []),
+    ('re', []),
+    ('red', [['red']]),
+    ('blue_green', [['blue_green'], ['blue', 'green']]),
+    ('blue_green_orange', [['blue', 'green', 'orange']]),
+    (
+        'blue_green_puce',
+        [['blue', 'green_puce'], ['blue', 'green', 'puce'], ['blue_green', 'puce']]
+    ),
+))
+def test_split_address(key, expected):
+    actual = [list(i) for i in dicts.split_address(key, PARENT)]
+    assert actual == expected
+
+
+def test_environ_to_config_dict_many():
+    environ = {
+        'TEST_RED': 'red',
+        'TEST_BLUE_GREEN_ORANGE': 'bge',
+        'TEST_BLUE_GREEN_PUCE': 'bgp',
+        'TEST_BLUE_GREEN': 'groo',
+        'TEST_PURPLE': 'purple',
+    }
+    err = io.StringIO()
+    actual = dicts.environ_to_config_dict('TEST_', PARENT, environ, err)
+    expected = {'blue': {'green': {'orange': 'bge'}}, 'red': 'red'}
+
+    assert actual == expected
+
+    errors = err.getvalue().splitlines()
+    assert errors == [
+        'Bad environment variables:',
+        'ambiguous: TEST_BLUE_GREEN_PUCE, TEST_BLUE_GREEN',
+        'unknown: TEST_PURPLE',
+    ]
+
+
+def test_environ_to_config_dict_single():
+    environ = {
+        'TEST_BLUE_GREEN_ORANGE': 'bge',
+    }
+    err = io.StringIO()
+    actual = dicts.environ_to_config_dict('TEST_', PARENT, environ, err)
+
+    expected = {'blue': {'green': {'orange': 'bge'}}}
+    assert actual == expected
+    assert err.getvalue() == ''


### PR DESCRIPTION
(The free plan [only allows one reviewer](https://github.com/orgs/community/discussions/23978) so I added one of you as a reviewer and the other as an "Assignee", whatever that is.)

So I managed to directly implement the given data example in #90 in Pydantic, and round-trip the original dict.

The only wrinkle is that pydantic out of the box doesn't seem to detect misspelled names (I have a test demonstrating this).  There is probably a way to do this with pydantic, or doing it ourselves would be a pleasant hour and generate code we could reuse elsewhere.

EDIT: I fixed the above, and pushed the change.

----

This is the minimal first step so we could still back out of pydantic if we didn't accept this pull request!  But it looks pretty OK.

After this would come:

- [ ] read from zero or more config files
- [ ] read from environment variables
- [ ] secrets
- [ ] replace `cf` variable

Secrets will be a parallel structure read from different files and env vars so you can't print it out or serialize it with the main configs by mistake.

