### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,20 @@
+name: Story
+description: File a story. A story is a concise description of a product improvement. Ideally stories address specific concerns related to user experience.
+labels: ["story"]
+body:
+  - type: textarea
+    attributes:
+      label: Why
+      description: The rationale behind a desired change. Any supportive product-related documentation should be referenced here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How
+      description: A short description of how assignees might approach implementing the change. Any technical documentation such as proposals should be references here.
+  - type: textarea
+    attributes:
+      label: What
+      description: A set of issues leading to accomplishing the story. These issues may span across multiple repositories. The set should be grouped into a task list using the markdown format. Essentially this is an implementation action plan.
+      value: |
+        - [ ]


### PR DESCRIPTION
Closes #114 

<img width="964" alt="image" src="https://github.com/SuperDuperDB/superduperdb-stealth/assets/1091425/0d937c1e-57d6-43d8-98bb-982b477a7aaa">

It is really easy to change. Later we could add a bug template  etc.