### PR TITLE
fix: linux installation with poetry

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,10 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install poetry
-        poetry remove torch
-        poetry source add --priority=explicit torch https://download.pytorch.org/whl/cpu
-        poetry add torch==2.0.1 --source=torch
-        poetry add sympy==1.12
         poetry install
     - name: Test
       run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -3848,10 +3848,10 @@ click = ">=7.0"
 filelock = "*"
 frozenlist = "*"
 grpcio = [
-    {version = ">=1.32.0,<=1.51.3", markers = "python_version < \"3.10\" and sys_platform != \"darwin\""},
     {version = ">=1.32.0,<=1.49.1", markers = "python_version < \"3.10\" and sys_platform == \"darwin\""},
-    {version = ">=1.42.0,<=1.51.3", markers = "python_version >= \"3.10\" and sys_platform != \"darwin\""},
     {version = ">=1.42.0,<=1.49.1", markers = "python_version >= \"3.10\" and sys_platform == \"darwin\""},
+    {version = ">=1.32.0,<=1.51.3", markers = "python_version < \"3.10\" and sys_platform != \"darwin\""},
+    {version = ">=1.42.0,<=1.51.3", markers = "python_version >= \"3.10\" and sys_platform != \"darwin\""},
 ]
 jsonschema = "*"
 msgpack = ">=1.0.0,<2.0.0"
@@ -4783,6 +4783,38 @@ typing-extensions = "*"
 opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
+name = "torch"
+version = "2.0.1+cpu"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "torch-2.0.1+cpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:fec257249ba014c68629a1994b0c6e7356e20e1afc77a87b9941a40e5095285d"},
+    {file = "torch-2.0.1+cpu-cp310-cp310-win_amd64.whl", hash = "sha256:ca88b499973c4c027e32c4960bf20911d7e984bd0c55cda181dc643559f3d93f"},
+    {file = "torch-2.0.1+cpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:274d4acf486ef50ce1066ffe9d500beabb32bde69db93e3b71d0892dd148956c"},
+    {file = "torch-2.0.1+cpu-cp311-cp311-win_amd64.whl", hash = "sha256:e2603310bdff4b099c4c41ae132192fc0d6b00932ae2621d52d87218291864be"},
+    {file = "torch-2.0.1+cpu-cp38-cp38-linux_x86_64.whl", hash = "sha256:8046f49deae5a3d219b9f6059a1f478ae321f232e660249355a8bf6dcaa810c1"},
+    {file = "torch-2.0.1+cpu-cp38-cp38-win_amd64.whl", hash = "sha256:2ac4382ff090035f9045b18afe5763e2865dd35f2d661c02e51f658d95c8065a"},
+    {file = "torch-2.0.1+cpu-cp39-cp39-linux_x86_64.whl", hash = "sha256:73482a223d577407c45685fde9d2a74ba42f0d8d9f6e1e95c08071dc55c47d7b"},
+    {file = "torch-2.0.1+cpu-cp39-cp39-win_amd64.whl", hash = "sha256:f263f8e908288427ae81441fef540377f61e339a27632b1bbe33cf78292fdaea"},
+]
+
+[package.dependencies]
+filelock = "*"
+jinja2 = "*"
+networkx = "*"
+sympy = "*"
+typing-extensions = "*"
+
+[package.extras]
+opt-einsum = ["opt-einsum (>=3.3)"]
+
+[package.source]
+type = "legacy"
+url = "https://download.pytorch.org/whl/cpu"
+reference = "torch"
+
+[[package]]
 name = "torchmetrics"
 version = "0.11.4"
 description = "PyTorch native Metrics"
@@ -5405,4 +5437,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1, <4.0"
-content-hash = "3c219e50781c4dedbe2e8524e7d0c61e352ea5f687847891432bd71b2810fe8c"
+content-hash = "76a4a00d2811ed132f6cf98997b5ef5dc681f1780e0469024de3b8a0c191c7c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,29 @@ werkzeug = "^2.3.4"
 openai = "^0.27.6"
 pydantic = "^1.10.7"
 fil = "^1.1.0"
-torch = "^2.0.1"
+torch = [
+     {version = "^2.0.1", platform = "darwin", source="PyPI"},
+     {version = "^2.0.1", platform = "linux", source = "torch"},
+     {version = "^2.0.1", platform = "win32", source = "torch"},
+ ]
 typer = "^0.9.0"
 ipykernel = "^6.23.1"
 ray = "^2.4.0"
 langchain = "^0.0.193"
 pymilvus = "^2.2.9"
+sympy = "^1.12"
 # pymilvus and ray are contributing to the version abmiguity
 grpcio = "<=1.49.1"
+
+[[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"
+
+[[tool.poetry.source]]
+name = "torch"
+url = "https://download.pytorch.org/whl/cpu"
+priority = "explicit"
+
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
Fix the current installation process on Linux. Add docker installation method to ensure containerization.


Notes to testers:
Tested both in Mac OS and Linux on docker and poetry with the following commands after ensuring that no mongodb instance is running:

### Poetry

To test in `poetry` run:
```shell
poetry install && poetry run make test
```

### Docker

To test using `docker` run:
```shell
docker compose run --build python poetry run pytest -vv --maxfail=3 tests/unittests
```


