### PR TITLE
Use Python 3.8.10 version in Dockerfile

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ["3.10"]
+        python-version: ["3.8"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@blythed as well.

Right now, we officially support only Python 3.8 through Python 3.10, because torch as of a week ago did not support 3.11.

I think we should be testing the _least_ version of the software we support, because there are going to be many programs that work in 3.10 and not in 3.8, and very few that work in 3.8 and not in 3.10.

For release, we should test Python 3.8, 3.9, 3.10 and soon, I hope, 3.11. 

3.8.10 is the last full release of Python 3.8, with installers for all systems.

