### PR TITLE
Integrate VectorDatabase into VectorIndex

### DIFF
--- a/superduperdb/datalayer/base/database.py
+++ b/superduperdb/datalayer/base/database.py
@@ -24,6 +24,16 @@ from superduperdb.misc.special_dicts import ArgumentDefaultDict
 from superduperdb.fetchers.downloads import Downloader
 from superduperdb.misc import progress
 from superduperdb.misc.logger import logging
+from superduperdb.vector_search.base import VectorDatabase
+
+
+# TODO:
+# This global variable is a temporary solution to make VectorDatabase available
+# to the rest of the code.
+# It should be moved to the Server's initialization code where it can be available to
+# all threads.
+VECTOR_DATABASE = VectorDatabase.create(config=CFG.vector_search)
+VECTOR_DATABASE.init().__enter__()
 
 
 class BaseDatabase:

--- a/superduperdb/datalayer/mongodb/query.py
+++ b/superduperdb/datalayer/mongodb/query.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field, asdict
 from functools import cached_property
 from typing import Optional, Mapping, Any
 
+from bson import ObjectId
+
 from superduperdb.core.documents import Document
 from superduperdb.datalayer.base import query
 
@@ -48,8 +50,10 @@ class Select(query.Select):
         self, ids, features: Optional[Mapping[str, str]] = None
     ) -> 'Select':
         variables = asdict(self)
+        # NOTE: here we assume that the _id field is ObjectId, although it may not be
+        # the case.
         variables['filter'] = {
-            '_id': {'$in': ids},
+            '_id': {'$in': [ObjectId(id_) for id_ in ids]},
             **(self.filter if self.filter else {}),
         }
         if features is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,15 @@ from unittest import mock
 import pytest
 
 from superduperdb.datalayer.mongodb.client import SuperDuperClient
+from superduperdb.vector_search.base import VectorDatabase
 
-from .conftest_mongodb import MongoDBConfig
-from superduperdb.misc import config as _config
+from .conftest_mongodb import MongoDBConfig as TestMongoDBConfig
+from superduperdb.misc.config import (
+    Config as SuperDuperConfig,
+    VectorSearchConfig,
+    MilvusConfig,
+    MongoDB as MongoDBConfig,
+)
 
 pytest_plugins = [
     "tests.conftest_mongodb",
@@ -16,7 +22,7 @@ pytest_plugins = [
 
 
 @contextmanager
-def create_client(*, mongodb_config: MongoDBConfig) -> Iterator[SuperDuperClient]:
+def create_client(*, mongodb_config: TestMongoDBConfig) -> Iterator[SuperDuperClient]:
     client = SuperDuperClient(
         host=mongodb_config.host,
         port=mongodb_config.port,
@@ -32,19 +38,36 @@ def create_client(*, mongodb_config: MongoDBConfig) -> Iterator[SuperDuperClient
 
 
 @pytest.fixture
-def client(mongodb_server: MongoDBConfig) -> Iterator[SuperDuperClient]:
+def client(mongodb_server: TestMongoDBConfig) -> Iterator[SuperDuperClient]:
     with create_client(mongodb_config=mongodb_server) as client:
         yield client
 
 
 @pytest.fixture(autouse=True)
-def config(mongodb_server: MongoDBConfig) -> Iterator[None]:
-    our_config = _config.MongoDB(
+def config(mongodb_server: TestMongoDBConfig) -> Iterator[None]:
+    mongodb_config = MongoDBConfig(
         host=mongodb_server.host,
         port=mongodb_server.port,
         user=mongodb_server.username,
         password=mongodb_server.password,
     )
-
-    with mock.patch('superduperdb.CFG.mongodb', our_config):
+    with mock.patch('superduperdb.CFG.mongodb', mongodb_config):
         yield
+
+
+@pytest.fixture
+def config_mongodb_milvus(
+    config: SuperDuperConfig, milvus_config: MilvusConfig
+) -> Iterator[None]:
+    vector_search_config = VectorSearchConfig(
+        milvus=milvus_config,
+    )
+    with mock.patch('superduperdb.CFG.vector_search', vector_search_config):
+        with VectorDatabase.create(
+            config=vector_search_config
+        ).init() as vector_database:
+            with mock.patch(
+                'superduperdb.datalayer.base.database.VECTOR_DATABASE',
+                vector_database,
+            ):
+                yield

--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -33,7 +33,8 @@ from tests.fixtures.collection import (
     si_validation,
     c_model,
     metric,
-    with_vector_index_faiss,
+    random_data_factory,
+    vector_index_factory,
 )
 from tests.material.losses import ranking_loss
 
@@ -128,17 +129,11 @@ def test_select(with_vector_index):
     assert r['_id'] == s['_id']
 
 
-def test_validate_component(with_vector_index, si_validation, metric):
-    with_vector_index.validate(
-        'test_vector_search',
-        variety='vector_index',
-        metrics=['p@1'],
-        validation_sets=['my_valid'],
-    )
-
-
-def test_select_faiss(with_vector_index_faiss):
-    db = with_vector_index_faiss
+def test_select_milvus(
+    config_mongodb_milvus, random_data_factory, vector_index_factory
+):
+    db = random_data_factory(number_data_points=5)
+    vector_index_factory(db, 'test_vector_search', measure='l2')
     r = next(db.execute(Select(collection='documents')))
     s = next(
         db.execute(
@@ -150,6 +145,15 @@ def test_select_faiss(with_vector_index_faiss):
         )
     )
     assert r['_id'] == s['_id']
+
+
+def test_validate_component(with_vector_index, si_validation, metric):
+    with_vector_index.validate(
+        'test_vector_search',
+        variety='vector_index',
+        metrics=['p@1'],
+        validation_sets=['my_valid'],
+    )
 
 
 def test_insert(random_data, a_watcher, an_update):

--- a/tests/unittests/training/test_query_dataset.py
+++ b/tests/unittests/training/test_query_dataset.py
@@ -4,6 +4,7 @@ from tests.fixtures.collection import (
     empty,
     float_tensors_16,
     float_tensors_32,
+    random_data_factory,
     random_data,
     a_watcher,
     a_model,


### PR DESCRIPTION
This PR integrates `VectorIndexManager` into `BaseDatabase` and `VectorIndex`. Note that backfill is not part of it, and will likely be implemented as part of the CDC story.

Still to be addressed:
- Rename `VectorIndexManager` to `VectorDatabase`
- Add some comments

This PR leaves `within_ids` unimplemented for both vector search backends. There's an issue to track this here: https://github.com/SuperDuperDB/superduperdb-stealth/issues/279