### PR TITLE
Simplify type.Type

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 files =
     superduperdb/apis/retry.py,
+    superduperdb/core/type.py,
     superduperdb/datalayer/base/artifacts.py,
     superduperdb/datalayer/base/imports.py,
     superduperdb/fetchers/**/*.py,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 files =
     superduperdb/apis/retry.py,
-    superduperdb/core/type.py,
+    superduperdb/core/encoder.py,
     superduperdb/datalayer/base/artifacts.py,
     superduperdb/datalayer/base/imports.py,
     superduperdb/fetchers/**/*.py,

--- a/superduperdb/core/documents.py
+++ b/superduperdb/core/documents.py
@@ -1,21 +1,21 @@
 import dataclasses as dc
 import typing as t
-from superduperdb.core.type import DataVar
+from superduperdb.core.encoder import Encodable
 
 
 @dc.dataclass
 class Document:
     """
-    A wrapper around an instance of dict or a DataVar which may be used to dump
+    A wrapper around an instance of dict or a Encodable which may be used to dump
     that resource to a mix of jsonable content or `bytes`
     """
 
-    content: t.Union[t.Dict, DataVar]
+    content: t.Union[t.Dict, Encodable]
 
     def _encode(self, r: t.Any):
         if isinstance(r, dict):
             return {k: self._encode(v) for k, v in r.items()}
-        elif isinstance(r, DataVar):
+        elif isinstance(r, Encodable):
             return r.encode()
         return r
 
@@ -50,7 +50,7 @@ class Document:
 
     @classmethod
     def _unpack_datavars(cls, item: t.Any):
-        if isinstance(item, DataVar):
+        if isinstance(item, Encodable):
             return item.x
         elif isinstance(item, dict):
             return {k: cls._unpack_datavars(v) for k, v in item.items()}

--- a/superduperdb/core/encoder.py
+++ b/superduperdb/core/encoder.py
@@ -68,7 +68,7 @@ class Encodable:
     """
 
     x: t.Any
-    type: Encoder
+    encoder: Encoder
 
     def encode(self) -> t.Dict[str, t.Any]:
-        return self.type.encode(self.x)
+        return self.encoder.encode(self.x)

--- a/superduperdb/core/model.py
+++ b/superduperdb/core/model.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
 from superduperdb.core.base import Component, Placeholder
-from superduperdb.core.type import Type
+from superduperdb.core.encoder import Encoder
 
 
 class Model(Component):
@@ -10,7 +10,7 @@ class Model(Component):
 
     :param object: Model object, e.g. sklearn model, etc..
     :param identifier: Unique identifying ID
-    :param type: Type instance (optional)
+    :param type: Encoder instance (optional)
     """
 
     variety = 'model'
@@ -19,7 +19,7 @@ class Model(Component):
         self,
         object: Any,
         identifier: str,
-        type: Optional[Union[Type, str]] = None,
+        type: Optional[Union[Encoder, str]] = None,
     ):
         super().__init__(identifier)
         self.object = object

--- a/superduperdb/core/vector_index.py
+++ b/superduperdb/core/vector_index.py
@@ -102,12 +102,12 @@ class VectorIndex(Component):
             raise NotImplementedError
         if not isinstance(self.indexing_watcher.model, Model):
             raise NotImplementedError
-        model_type = self.indexing_watcher.model.type
-        if isinstance(model_type, Placeholder):
+        model_encoder = self.indexing_watcher.model.encoder
+        if isinstance(model_encoder, Placeholder):
             raise NotImplementedError
         try:
-            dimensions = model_type and model_type.shape and int(model_type.shape[-1])
-        except (IndexError, TypeError, ValueError):
+            dimensions = int(model_encoder.shape[-1])
+        except Exception:
             dimensions = None
         if not dimensions:
             raise ValueError(

--- a/superduperdb/core/vector_index.py
+++ b/superduperdb/core/vector_index.py
@@ -10,8 +10,8 @@ from superduperdb.core.base import (
     DBPlaceholder,
 )
 from superduperdb.core.documents import Document
+from superduperdb.core.encoder import Encodable
 from superduperdb.core.metric import Metric
-from superduperdb.core.type import DataVar
 from superduperdb.core.watcher import Watcher
 from superduperdb.core.model import Model
 from superduperdb.datalayer.base.query import Select
@@ -90,7 +90,7 @@ class VectorIndex(Component):
                     self.indexing_watcher.key,
                     self.indexing_watcher.model.identifier,
                 )
-                if isinstance(h, DataVar):
+                if isinstance(h, Encodable):
                     h = h.x
                 vector_collection.add(
                     [VectorCollectionItem.create(id=str(id), vector=h)]

--- a/superduperdb/datalayer/base/database.py
+++ b/superduperdb/datalayer/base/database.py
@@ -139,8 +139,8 @@ class BaseDatabase:
         opts = self.metadata.get_component('model', model_identifier)
         if isinstance(input, Document):
             out = model.predict_one(input.unpack(), **opts.get('predict_kwargs', {}))
-            if model.type is not None:
-                out = model.type(out)
+            if model.encoder is not None:
+                out = model.encoder(out)
             return Document(out)
 
         out = model.predict(
@@ -148,8 +148,8 @@ class BaseDatabase:
         )
         to_return = []
         for x in out:
-            if model.type is not None:
-                x = model.type(x)
+            if model.encoder is not None:
+                x = model.encoder(x)
             to_return.append(Document(x))
         return to_return
 

--- a/superduperdb/models/sentence_transformers/wrapper.py
+++ b/superduperdb/models/sentence_transformers/wrapper.py
@@ -11,12 +11,12 @@ class SentenceTransformer(Model):
         self,
         model_name_or_path: Optional[str] = None,
         identifier: Optional[str] = None,
-        type: Optional[Union[Encoder, str]] = None,
+        encoder: Union[Encoder, None, str] = None,
     ):
         if identifier is None:
             identifier = model_name_or_path
         sentence_transformer = _SentenceTransformer(model_name_or_path)
-        super().__init__(sentence_transformer, identifier, type=type)
+        super().__init__(sentence_transformer, identifier, encoder=encoder)
 
     def predict_one(self, sentence, **kwargs):
         return self.object.encode(sentence)

--- a/superduperdb/models/sentence_transformers/wrapper.py
+++ b/superduperdb/models/sentence_transformers/wrapper.py
@@ -2,8 +2,8 @@ from typing import Optional, Union
 
 from sentence_transformers import SentenceTransformer as _SentenceTransformer
 
+from superduperdb.core.encoder import Encoder
 from superduperdb.core.model import Model
-from superduperdb.core.type import Type
 
 
 class SentenceTransformer(Model):
@@ -11,7 +11,7 @@ class SentenceTransformer(Model):
         self,
         model_name_or_path: Optional[str] = None,
         identifier: Optional[str] = None,
-        type: Optional[Union[str, Type]] = None,
+        type: Optional[Union[Encoder, str]] = None,
     ):
         if identifier is None:
             identifier = model_name_or_path

--- a/superduperdb/models/sklearn/wrapper.py
+++ b/superduperdb/models/sklearn/wrapper.py
@@ -10,10 +10,10 @@ class Pipeline(BasePipeline, Model):
         memory=None,
         verbose=False,
         postprocessor=None,
-        type=None,
+        encoder=None,
     ):
         BasePipeline.__init__(self, steps=steps, memory=memory, verbose=verbose)
-        Model.__init__(self, None, identifier, type=type)
+        Model.__init__(self, None, identifier, encoder=encoder)
         self.postprocessor = postprocessor
 
     def predict_one(self, X, **predict_params):

--- a/superduperdb/models/torch/wrapper.py
+++ b/superduperdb/models/torch/wrapper.py
@@ -18,11 +18,11 @@ class SuperDuperModule(torch.nn.Module, Model):
         identifier,
         preprocess=None,
         postprocess=None,
-        type=None,
+        encoder=None,
         collate_fn: Optional[Callable] = None,
     ):
         torch.nn.Module.__init__(self)
-        Model.__init__(self, layer, identifier, type=type)
+        Model.__init__(self, layer, identifier, encoder=encoder)
         if hasattr(self.object, 'preprocess') and preprocess is None:
             preprocess = self.object.preprocess
         if hasattr(self.object, 'postprocess') and postprocess is None:

--- a/superduperdb/models/torch/wrapper.py
+++ b/superduperdb/models/torch/wrapper.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils import data
 
 from superduperdb.core.documents import Document
-from superduperdb.core.type import DataVar
+from superduperdb.core.encoder import Encodable
 from superduperdb.misc import progress
 from superduperdb.core.model import Model
 from superduperdb.models.torch.utils import device_of, to_device, eval
@@ -177,7 +177,7 @@ class BasicDataset(data.Dataset):
         document = self.documents[item]
         if isinstance(document, Document):
             document = document.unpack()
-        elif isinstance(document, DataVar):
+        elif isinstance(document, Encodable):
             document = document.x
         return self.transform(document)
 

--- a/superduperdb/types/numpy/array.py
+++ b/superduperdb/types/numpy/array.py
@@ -1,7 +1,7 @@
 import numpy
 import typing as t
 
-from superduperdb.core.type import Type
+from superduperdb.core.encoder import Encoder
 from superduperdb.types.utils import str_shape
 
 
@@ -23,7 +23,7 @@ class DecodeArray:
 
 
 def array(dtype: str, shape: t.Tuple):
-    return Type(
+    return Encoder(
         identifier=f'numpy.{dtype}[{str_shape(shape)}]',
         encoder=EncodeArray(dtype),
         decoder=DecodeArray(dtype),

--- a/superduperdb/types/pillow/image.py
+++ b/superduperdb/types/pillow/image.py
@@ -3,7 +3,7 @@ import PIL.JpegImagePlugin
 import PIL.PngImagePlugin
 import io
 
-from superduperdb.core.type import Type
+from superduperdb.core.encoder import Encoder
 
 
 def encode_pil_image(x):
@@ -16,7 +16,7 @@ def decode_pil_image(bytes):
     return PIL.Image.open(io.BytesIO(bytes))
 
 
-pil_image = Type(
+pil_image = Encoder(
     'pil_image',
     encoder=encode_pil_image,
     decoder=decode_pil_image,

--- a/superduperdb/types/torch/tensor.py
+++ b/superduperdb/types/torch/tensor.py
@@ -2,7 +2,7 @@ import numpy
 import torch
 import typing as t
 
-from superduperdb.core.type import Type
+from superduperdb.core.encoder import Encoder
 from superduperdb.types.utils import str_shape
 
 
@@ -25,7 +25,7 @@ class DecodeTensor:
 
 
 def tensor(dtype, shape: t.Tuple):
-    return Type(
+    return Encoder(
         identifier=f'{str(dtype)}[{str_shape(shape)}]',
         encoder=EncodeTensor(dtype),
         decoder=DecodeTensor(dtype),

--- a/tests/fixtures/collection.py
+++ b/tests/fixtures/collection.py
@@ -198,7 +198,9 @@ def image_type(empty):
 @pytest.fixture()
 def a_model(float_tensors_32, float_tensors_16):
     float_tensors_32.add(
-        SuperDuperModule(torch.nn.Linear(32, 16), 'linear_a', type='torch.float32[16]')
+        SuperDuperModule(
+            torch.nn.Linear(32, 16), 'linear_a', encoder='torch.float32[16]'
+        )
     )
     yield float_tensors_32
     try:
@@ -212,7 +214,9 @@ def a_model(float_tensors_32, float_tensors_16):
 @pytest.fixture()
 def a_model_base(float_tensors_32, float_tensors_16):
     float_tensors_32.add(
-        SuperDuperModule(LinearBase(32, 16), 'linear_a_base', type='torch.float32[16]'),
+        SuperDuperModule(
+            LinearBase(32, 16), 'linear_a_base', encoder='torch.float32[16]'
+        ),
     )
     yield float_tensors_32
     try:
@@ -257,7 +261,9 @@ def a_classifier(float_tensors_32):
 @pytest.fixture()
 def b_model(float_tensors_32, float_tensors_16, float_tensors_8):
     float_tensors_32.add(
-        SuperDuperModule(torch.nn.Linear(16, 8), 'linear_b', type='torch.float32[8]'),
+        SuperDuperModule(
+            torch.nn.Linear(16, 8), 'linear_b', encoder='torch.float32[8]'
+        ),
     )
     yield float_tensors_32
     try:
@@ -274,7 +280,7 @@ def c_model(float_tensors_32, float_tensors_16):
         SuperDuperModule(
             torch.nn.Linear(32, 16),
             'linear_c',
-            type='torch.float32[16]',
+            encoder='torch.float32[16]',
         ),
     )
     yield float_tensors_32

--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -68,7 +68,7 @@ def test_compound_component(empty):
     m = SuperDuperModule(
         layer=torch.nn.Linear(16, 32),
         identifier='my-test-module',
-        type=t,
+        encoder=t,
     )
 
     empty.add(m)
@@ -84,17 +84,17 @@ def test_compound_component(empty):
         SuperDuperModule(
             layer=torch.nn.Linear(16, 32),
             identifier='my-test-module',
-            type=t,
+            encoder=t,
         )
     )
     assert empty.show('model', 'my-test-module') == [0, 1]
     assert empty.show('type', 'torch.float32[32]') == [0]
 
     m = empty.load(variety='model', identifier='my-test-module', repopulate=False)
-    assert isinstance(m.type, Placeholder)
+    assert isinstance(m.encoder, Placeholder)
 
     m = empty.load(variety='model', identifier='my-test-module', repopulate=True)
-    assert isinstance(m.type, Encoder)
+    assert isinstance(m.encoder, Encoder)
 
     with pytest.raises(ComponentInUseError):
         empty.remove('type', 'torch.float32[32]')
@@ -104,7 +104,7 @@ def test_compound_component(empty):
 
     # checks that can reload hidden type if part of another component
     m = empty.load(variety='model', identifier='my-test-module', repopulate=True)
-    assert isinstance(m.type, Encoder)
+    assert isinstance(m.encoder, Encoder)
 
     empty.remove('model', 'my-test-module', force=True)
 

--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -5,9 +5,9 @@ import torch
 
 from superduperdb.core.base import Placeholder
 from superduperdb.core.documents import Document
+from superduperdb.core.encoder import Encoder
 from superduperdb.core.exceptions import ComponentInUseError, ComponentInUseWarning
 from superduperdb.core.learning_task import LearningTask
-from superduperdb.core.type import Type
 from superduperdb.core.watcher import Watcher
 from superduperdb.datalayer.mongodb.query import Select, Insert, Update, Delete
 from superduperdb.models.torch.wrapper import SuperDuperModule
@@ -94,7 +94,7 @@ def test_compound_component(empty):
     assert isinstance(m.type, Placeholder)
 
     m = empty.load(variety='model', identifier='my-test-module', repopulate=True)
-    assert isinstance(m.type, Type)
+    assert isinstance(m.type, Encoder)
 
     with pytest.raises(ComponentInUseError):
         empty.remove('type', 'torch.float32[32]')
@@ -104,7 +104,7 @@ def test_compound_component(empty):
 
     # checks that can reload hidden type if part of another component
     m = empty.load(variety='model', identifier='my-test-module', repopulate=True)
-    assert isinstance(m.type, Type)
+    assert isinstance(m.type, Encoder)
 
     empty.remove('model', 'my-test-module', force=True)
 

--- a/tests/unittests/models/test_langchain.py
+++ b/tests/unittests/models/test_langchain.py
@@ -19,7 +19,7 @@ if not SKIP_PAID:
 @pytest.mark.skipif(SKIP_PAID, reason='don\'t test paid API')
 def test_db_qa_with_sources_chain(nursery_rhymes):
     nursery_rhymes.add(array(numpy.float32))
-    pl = SentenceTransformer(model_name_or_path='all-MiniLM-L6-v2', type='array')
+    pl = SentenceTransformer(model_name_or_path='all-MiniLM-L6-v2', encoder='array')
     nursery_rhymes.add(pl)
     nursery_rhymes.add(
         Watcher(model='all-MiniLM-L6-v2', key='text', select=Select('documents'))


### PR DESCRIPTION
All right, I hope this will entertain you!

This is preparatory to renaming `Type` and `variety`, I felt I should do it with the old, familiar names.

This is a refactoring where most of the code vanishes.

----

A `Component` cannot directly be a `dataclass`, I learned on this review. 

The standard technique seems to be to create a separate dataclass and use multiple inheritance, which worked very well.

I suspect we will use this trick a lot.