### PR TITLE
improve performance of VectorIndex.repopulate

### DIFF
--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -142,7 +142,6 @@ def test_select(with_vector_index):
     assert r['_id'] == s['_id']
 
 
-@pytest.mark.skip(reason='See issue #291')
 def test_select_milvus(
     config_mongodb_milvus, random_data_factory, vector_index_factory
 ):


### PR DESCRIPTION
Closes #329 

it used to take
```shell
pytest -vv -x --pdb -s --log-cli-level=DEBUG   3.84s user 1.28s system 24% cpu 20.877 total
```

and now
```shell
time pytest -vv -x --pdb -s --log-cli-level=DEBUG tests/unittests/datalayer/mongodb/test_database.py::test_select_milvus 
...
pytest -vv -x --pdb -s --log-cli-level=DEBUG   3.71s user 0.98s system 60% cpu 7.699 total
```

`pymilvus.Collection.search` takes a while:
```
0.16069269299999966
0.20032544300000055
0.19914560700000017
0.39996797299999987
0.1995876249999995
0.20046617499999986
0.3999589109999997
0.3994273910000006
0.20042636400000013
0.39739911899999925
```