### PR TITLE
Add misc/dataclasses.py

### DIFF
--- a/superduperdb/core/documents.py
+++ b/superduperdb/core/documents.py
@@ -1,16 +1,15 @@
 from superduperdb.core.encoder import Encodable
-import dataclasses as dc
+from superduperdb.misc.uri_cache import Cached
 import typing as t
 
+ContentType = t.Union[t.Dict, Encodable]
 
-@dc.dataclass
-class Document:
+
+class Document(Cached[ContentType]):
     """
     A wrapper around an instance of dict or a Encodable which may be used to dump
     that resource to a mix of jsonable content or `bytes`
     """
-
-    content: t.Union[t.Dict, Encodable]
 
     def __hash__(self):
         return super().__hash__()

--- a/superduperdb/misc/dataclasses.py
+++ b/superduperdb/misc/dataclasses.py
@@ -1,0 +1,51 @@
+from dataclasses import (
+    InitVar,
+    MISSING,
+    asdict,
+    astuple,
+    field,
+    fields,
+    is_dataclass,
+    replace,
+)
+from pydantic import dataclasses as pdc
+import functools
+
+__all__ = (
+    'InitVar',
+    'MISSING',
+    'add_methods',
+    'asdict',
+    'astuple',
+    'field',
+    'fields',
+    'is_dataclass',
+    'replace',
+)
+
+_METHODS = 'asdict', 'astuple', 'dict', 'fields', 'replace'
+_CLASS_METHODS = ('fields',)
+
+
+@functools.wraps(pdc.dataclass)
+def dataclass(cls=None, **kwargs):
+    if not cls:
+        return functools.partial(dataclass, **kwargs)
+
+    return add_methods(pdc.dataclass(cls, **kwargs))
+
+
+def add_methods(dcls):
+    """Adds dataclasses functions as methods to a dataclass.
+
+    Adds four new instance methods, `asdict()`, `astuple()`, `dict()`, and `replace()`
+    and a new class method, `fields()`.
+    """
+    for m in _METHODS:
+        if not hasattr(dcls, m):
+            method = asdict if m == 'dict' else globals()[m]
+            if m in _CLASS_METHODS:
+                method = classmethod(method)
+            setattr(dcls, m, method)
+
+    return dcls

--- a/superduperdb/misc/for_each.py
+++ b/superduperdb/misc/for_each.py
@@ -1,0 +1,33 @@
+from superduperdb.misc import dataclasses as dc
+import superduperdb as s
+import typing as t
+
+
+def for_each(
+    fn: t.Callable[[t.Any], t.Any], item: t.Any, depth_first: bool = False
+) -> None:
+    """
+    Recursively applies a function, breadth-first.
+
+    `for_each` recurses through dicts, lists and tuples, and also through
+    members of dataclasses and Pydantic models.
+    """
+    if not depth_first:
+        fn(item)
+
+    it: t.Iterable = ()
+
+    if isinstance(item, (list, tuple)):
+        it = item
+    elif isinstance(item, dict):
+        it = item.values()
+    elif dc.is_dataclass(item):
+        it = (getattr(item, f.name) for f in dc.fields(item))
+    elif isinstance(item, s.JSONable):
+        it = (getattr(item, i) for i in item.schema()['properties'])
+
+    for i in it:
+        for_each(fn, i)
+
+    if depth_first:
+        fn(item)

--- a/superduperdb/misc/typed_cache.py
+++ b/superduperdb/misc/typed_cache.py
@@ -42,6 +42,15 @@ class TypedCache:
         name, key = key.split(SEP)
         return self._name_to_cache[name].get(key)
 
+    def expire(self, before: float) -> t.Dict[t.Type, t.Dict[str, t.Any]]:
+        cn = self._class_to_name.items()
+        cc = ((cls, self._name_to_cache[name]) for cls, name in cn)
+        return {cls: cache.expire(before) for cls, cache in cc}
+
+    def __len__(self):
+        with self._lock:
+            return sum(len(i) for i in self._name_to_cache.values())
+
     _class_to_name: t.Dict[t.Type, str] = dc.field(default_factory=dict)
     _lock: Lock = dc.field(default_factory=Lock)
     _name_to_cache: t.Dict[str, KeyCache] = dc.field(default_factory=dict)

--- a/superduperdb/misc/typed_cache.py
+++ b/superduperdb/misc/typed_cache.py
@@ -1,0 +1,47 @@
+from .key_cache import KeyCache
+from threading import Lock
+from superduperdb.misc import dataclasses as dc
+import typing as t
+
+SEP = '-'
+
+
+@dc.dataclass
+class TypedCache:
+    """Cache objects by class.
+
+    Each class of object is given a unique name and its own cache.
+
+    The key for an object is that unique class name, joined with the object's key from
+    its class cache.
+    """
+
+    def put(self, entry: t.Any) -> str:
+        """Put an item into the cache, return a string key"""
+        name = self._get_name(type(entry))
+        cache = self._name_to_cache[name]
+        key = cache.put(entry)
+        return f'{name}{SEP}{key}'
+
+    def _get_name(self, cls: t.Type) -> str:
+        with self._lock:
+            try:
+                return self._class_to_name[cls]
+            except KeyError:
+                name = cls.__name__
+                if name in self._name_to_cache:
+                    name = f'{cls.__module__}.{name}'
+                cache = KeyCache[cls]()  # type: ignore
+
+                self._class_to_name[cls] = name
+                self._name_to_cache[name] = cache
+        return name
+
+    def get(self, key: str) -> t.Any:
+        """Given a key, returns an entry or raises KeyError"""
+        name, key = key.split(SEP)
+        return self._name_to_cache[name].get(key)
+
+    _class_to_name: t.Dict[t.Type, str] = dc.field(default_factory=dict)
+    _lock: Lock = dc.field(default_factory=Lock)
+    _name_to_cache: t.Dict[str, KeyCache] = dc.field(default_factory=dict)

--- a/superduperdb/misc/uri_cache.py
+++ b/superduperdb/misc/uri_cache.py
@@ -1,0 +1,56 @@
+from .for_each import for_each
+from .typed_cache import TypedCache
+import typing as t
+
+if t.TYPE_CHECKING:
+    import dataclasses as dc
+else:
+    from . import dataclasses as dc
+
+
+ContentType = t.TypeVar('ContentType')
+
+
+@dc.dataclass
+class Cached(t.Generic[ContentType]):
+    """A base class for classes that are cached using their uri and type"""
+
+    _content: dc.InitVar[ContentType] = None
+    uri: str = ''
+
+    @property
+    def content(self) -> ContentType:
+        """Get the cached content. `content` is not JSONized"""
+        return self._content  # type: ignore[return-value, attr-defined]
+
+    @content.setter
+    def content(self, content: ContentType):
+        """Set the cached content. `content` is not JSONized"""
+        self._content = content  # type: ignore[return-value, attr-defined]
+
+    def __post_init__(self, content: ContentType):
+        self.content = content
+
+
+class URICache(TypedCache):
+    """
+    A typed cache for instances of `Cached`.
+    """
+
+    def cache(self, entry):
+        """Add a uri to the content in an instance of Cached"""
+        if isinstance(entry, Cached):
+            entry.uri = self.put(entry.content)
+
+    def uncache(self, entry: t.Any) -> None:
+        """Retrieve the content from the uri in an instance of Cached"""
+        if isinstance(entry, Cached):
+            entry.content = self.get(entry.uri)
+
+    def cache_all(self, entry: t.Any) -> None:
+        """Run self.cache recursively"""
+        for_each(self.cache, entry)
+
+    def uncache_all(self, entry: t.Any) -> None:
+        """Run self.uncache recursively"""
+        for_each(self.uncache, entry)

--- a/tests/unittests/misc/test_dataclasses.py
+++ b/tests/unittests/misc/test_dataclasses.py
@@ -48,6 +48,7 @@ class Inclus:
 
 def test_dataclasses():
     assert Un(eleven='HAHA!').dict() == UN
+    assert Un(eleven='HAHA!').eleven == 'HAHA!'
     assert Inclus(Un()).asdict() == {'ein': UN}
     assert Inclus(**{'ein': UN}) == Inclus(Un())
 

--- a/tests/unittests/misc/test_dataclasses.py
+++ b/tests/unittests/misc/test_dataclasses.py
@@ -1,0 +1,60 @@
+from pydantic import Field
+from superduperdb.misc import dataclasses as dc
+
+
+@dc.dataclass
+class Un:
+    un: str = 'un'
+
+    # These two unfortunately get JSONized
+    nine: str = Field(default='ERROR', exclude=True)
+    ten: str = dc.field(default='ERROR', repr=False, compare=False)
+    eleven: dc.InitVar[str] = 'this goes up to'
+
+    def __post_init__(self, eleven: str):
+        self.seven = self.un + '-sept'
+        self.eleven = eleven
+
+
+UN = {
+    'un': 'un',
+    'nine': 'ERROR',
+    'ten': 'ERROR',
+}
+
+
+@dc.dataclass
+class Deux(Un):
+    deux: str = 'deux'
+
+
+@dc.dataclass
+class Trois(Un):
+    deux: str = 'trois'
+
+
+class Objet:
+    def premier(self, un: Un) -> Deux:
+        return Deux(**un.dict())
+
+    def second(self, un: Un, trois: Trois) -> Un:
+        return un
+
+
+@dc.dataclass
+class Inclus:
+    ein: Un
+
+
+def test_dataclasses():
+    assert Un(eleven='HAHA!').dict() == UN
+    assert Inclus(Un()).asdict() == {'ein': UN}
+    assert Inclus(**{'ein': UN}) == Inclus(Un())
+
+    actual = Inclus(Un()).replace(ein=Un().replace(nine='nine')).dict()
+    expected = {'ein': dict(UN, nine='nine')}
+    assert actual == expected
+
+
+def test_methods():
+    assert [f.name for f in Un.fields()] == ['un', 'nine', 'ten']

--- a/tests/unittests/misc/test_for_each.py
+++ b/tests/unittests/misc/test_for_each.py
@@ -1,0 +1,77 @@
+from pydantic import dataclasses as dc
+from superduperdb.misc.for_each import for_each
+import superduperdb as s
+import typing as t
+
+
+@dc.dataclass
+class One:
+    one: t.Dict
+    uno: t.List
+    eins: str = ''
+
+
+class Two(s.JSONable):
+    one: One
+    nine: t.List[One]
+
+
+ONE = One(one={'a': 'b'}, uno=['hello', 'world'], eins='zed')
+TWO = Two(one=ONE, nine=[ONE, One({}, [])])
+
+BREADTH = [
+    TWO,
+    ONE,
+    {'a': 'b'},
+    'b',
+    ['hello', 'world'],
+    'hello',
+    'world',
+    'zed',
+    [ONE, One(one={}, uno=[], eins='')],
+    ONE,
+    {'a': 'b'},
+    'b',
+    ['hello', 'world'],
+    'hello',
+    'world',
+    'zed',
+    One(one={}, uno=[], eins=''),
+    {},
+    [],
+    '',
+]
+DEPTH = [
+    ONE,
+    {'a': 'b'},
+    'b',
+    ['hello', 'world'],
+    'hello',
+    'world',
+    'zed',
+    [ONE, One(one={}, uno=[], eins='')],
+    ONE,
+    {'a': 'b'},
+    'b',
+    ['hello', 'world'],
+    'hello',
+    'world',
+    'zed',
+    One(one={}, uno=[], eins=''),
+    {},
+    [],
+    '',
+    TWO,
+]
+
+
+def test_for_each_breadth():
+    actual = []
+    for_each(actual.append, TWO)
+    assert actual == BREADTH
+
+
+def test_for_each_depth():
+    actual = []
+    for_each(actual.append, TWO, depth_first=True)
+    assert actual == DEPTH

--- a/tests/unittests/misc/test_typed_cache.py
+++ b/tests/unittests/misc/test_typed_cache.py
@@ -1,0 +1,11 @@
+from superduperdb.misc.typed_cache import TypedCache
+
+
+def test_typed_cache():
+    cache = TypedCache()
+
+    assert cache.put(23) == 'int-0'
+    assert cache.put('123') == 'str-0'
+
+    assert cache.get('int-0') == 23
+    assert cache.get('str-0') == '123'

--- a/tests/unittests/misc/test_typed_cache.py
+++ b/tests/unittests/misc/test_typed_cache.py
@@ -1,11 +1,31 @@
 from superduperdb.misc.typed_cache import TypedCache
+from unittest import mock
 
 
 def test_typed_cache():
+    now = 0
+
+    def time():
+        nonlocal now
+        now += 1
+        return now - 1
+
     cache = TypedCache()
 
-    assert cache.put(23) == 'int-0'
-    assert cache.put('123') == 'str-0'
+    with mock.patch('time.time', side_effect=time):
+        assert cache.put(23) == 'int-0'
+        assert cache.put('123') == 'str-0'
 
-    assert cache.get('int-0') == 23
-    assert cache.get('str-0') == '123'
+        assert cache.get('int-0') == 23
+        assert cache.get('str-0') == '123'
+
+        assert cache.put(32) == 'int-1'
+        assert cache.put(235) == 'int-2'
+
+        assert len(cache) == 4
+
+        removed = cache.expire(3)
+        assert len(cache) == 1
+
+        expected = {int: {'0': 23, '1': 32}, str: {'0': '123'}}
+        assert removed == expected

--- a/tests/unittests/misc/test_uri_cache.py
+++ b/tests/unittests/misc/test_uri_cache.py
@@ -1,0 +1,67 @@
+import superduperdb as s
+import typing as t
+from superduperdb.misc import dataclasses as dc
+from superduperdb.misc import uri_cache
+
+
+class Str(uri_cache.Cached[str]):
+    def __hash__(self):
+        return object.__hash__(self)
+
+
+class Tuple(uri_cache.Cached[tuple]):
+    def __hash__(self):
+        return object.__hash__(self)
+
+
+@dc.dataclass
+class Both:
+    s: Str
+    t: Tuple
+
+
+class Top(s.JSONable):
+    both: Both
+    d: t.Dict
+    li: t.List
+
+    def __hash__(self):
+        return object.__hash__(self)
+
+
+def test_cache_uri():
+    def tr(n):
+        return tuple(range(n))
+
+    top = Top(
+        both=Both(Str('hello'), Tuple(tr(3))),
+        d={'one': Str('wot')},
+        li=[Tuple(tr(10)), tr(10)],
+    )
+
+    actual1 = top.dict()
+    expected1 = {
+        'both': Both(s=Str(uri=''), t=Tuple(uri='')),
+        'd': {'one': Str(uri='')},
+        'li': [Tuple(uri=''), tr(10)],
+    }
+    assert actual1 == expected1
+
+    cache = uri_cache.URICache()
+    cache.cache_all(top)
+
+    actual2 = top.dict()
+    expected2 = {
+        'both': Both(s=Str(uri='str-0'), t=Tuple(uri='tuple-0')),
+        'd': {'one': Str(uri='str-1')},
+        'li': [Tuple(uri='tuple-1'), tr(10)],
+    }
+    assert actual2 == expected2
+
+    top2 = Top(**actual2)
+    cache.uncache_all(top2)
+
+    assert top2.both.s.content == 'hello'
+    assert top2.both.t.content == tr(3)
+    assert top2.d['one'].content == 'wot'
+    assert top2.li[0].content == tr(10)


### PR DESCRIPTION
Using `pydantic.dataclasses`, we lost the `dict()` method and have to use `dataclasses.asdict()`, which means a lot of pointless if statements.

Also, we have to remember to use `pydantic.dataclasses.dataclass`, and manipulate it with free functions from `dataclasses`, all of which would be better on the class.

Typical code is like this:

```
from superduperdb.misc import dataclasses as dc

@dc.dataclass
class One:
    one: str
    two: int = 2
    three: t.Dict = dc.field(default_factory=dict)

print(*(f.name for f in One.fields()))
# one two three

print(One('uno').dict())
# {'one': 'uno', 'two': 2, 'three': {}}
```