### PR TITLE
GH-372: Add missing methods to `ComponentList.repopulate`

### DIFF
--- a/superduperdb/core/base.py
+++ b/superduperdb/core/base.py
@@ -223,23 +223,26 @@ class ComponentList(BaseComponent):
     List of base components.
     """
 
-    def __init__(self, variety, components):
+    def __init__(self, variety: str, components: t.List[Component]):
         self.variety = variety
         self.components = components
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> Component:
         return self.components[item]
 
-    def __iter__(self):
+    def __setitem__(self, idx: int, value: Component):
+        self.components[idx] = value
+
+    def __iter__(self) -> t.Iterator[Component]:
         return iter(self.components)
 
-    def repopulate(self, database):
+    def repopulate(self, database: 'BaseDatabase') -> None:
         for i, item in enumerate(self):
             if isinstance(item, str):
                 self[i] = database.load(self.variety, item)
-            self[i], _ = self[i].repopulate(database)
+            self[i] = self[i].repopulate(database)
 
-    def aslist(self):
+    def aslist(self) -> t.List[str]:
         return [c.identifier for c in self]
 
 

--- a/superduperdb/core/fit.py
+++ b/superduperdb/core/fit.py
@@ -3,8 +3,8 @@ import typing as t
 from superduperdb.core.base import (
     Component,
     ComponentList,
-    PlaceholderList,
     Placeholder,
+    PlaceholderList,
     is_placeholders_or_components,
 )
 from superduperdb.core.metric import Metric
@@ -59,7 +59,7 @@ class Fit(Component):
         if metrics_are_strs:
             self.metrics = PlaceholderList('metric', metrics)  # type: ignore[arg-type]
         else:
-            self.metrics = ComponentList('metric', metrics)
+            self.metrics = ComponentList('metric', metrics)  # type: ignore[arg-type]
 
         self.keys = keys
         # ruff: noqa: E501

--- a/superduperdb/core/vector_index.py
+++ b/superduperdb/core/vector_index.py
@@ -1,15 +1,14 @@
-import typing as t
 import itertools
+import typing as t
 from contextlib import contextmanager
 
-from superduperdb.datalayer.base.query import Select
 from superduperdb.core.base import (
-    ComponentList,
-    PlaceholderList,
     Component,
-    Placeholder,
-    is_placeholders_or_components,
+    ComponentList,
     DBPlaceholder,
+    Placeholder,
+    PlaceholderList,
+    is_placeholders_or_components,
 )
 from superduperdb.core.dataset import Dataset
 from superduperdb.core.documents import Document
@@ -17,14 +16,15 @@ from superduperdb.core.encoder import Encodable
 from superduperdb.core.metric import Metric
 from superduperdb.core.model import Model, ModelEnsemble
 from superduperdb.core.watcher import Watcher
+from superduperdb.datalayer.base.query import Select
+from superduperdb.metrics.vector_search import VectorSearchPerformance
 from superduperdb.misc.logger import logging
 from superduperdb.misc.special_dicts import MongoStyleDict
-from superduperdb.metrics.vector_search import VectorSearchPerformance
 from superduperdb.vector_search.base import (
     VectorCollection,
     VectorCollectionConfig,
-    VectorIndexMeasureType,
     VectorCollectionItem,
+    VectorIndexMeasureType,
 )
 
 T = t.TypeVar('T')
@@ -88,7 +88,9 @@ class VectorIndex(Component):
                     'watcher', compatible_watchers  # type: ignore[arg-type]
                 )
             else:
-                self.compatible_watchers = ComponentList('watcher', compatible_watchers)
+                self.compatible_watchers = ComponentList(
+                    'watcher', t.cast(t.List[Component], compatible_watchers)
+                )
         self.measure = measure
         self.database = DBPlaceholder()
 
@@ -244,7 +246,7 @@ class VectorIndex(Component):
         return VectorSearchPerformance(
             measure=self.measure,
             index_key=self.indexing_watcher.key,  # type: ignore[union-attr]
-            compatible_keys=[w.key for w in self.compatible_watchers],
+            compatible_keys=[w.key for w in self.compatible_watchers],  # type: ignore[union-attr]
         )(
             validation_data=unpacked,
             model=model_ensemble,


### PR DESCRIPTION
**What is done**
This is an attempt at fixing #372. It adds a new `__setitem__` method, fixes internal usage of `.repopulate` and adds some basic type hints.

**Comments**
I can't get `mypy` to recognise my casting. (I would prefer to cast rather than ignore.) Have someone a fix for this? If not, I will remove `cast` methods and just ignore these lines. 😿 