### PR TITLE
Ignore warnings by default in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTEST_ARGUMENTS ?= -W ignore
+
 dist/.built: pyproject.toml $(shell find superduperdb)
 	poetry build --format=wheel
 	touch $@

--- a/tests/unittests/test_impall.py
+++ b/tests/unittests/test_impall.py
@@ -4,3 +4,5 @@ import impall
 class ImpAllTest(impall.ImpAllTest):
     # Do not reload modules for each file tested
     CLEAR_SYS_MODULES = False
+
+    WARNINGS_ACTION = 'ignore'


### PR DESCRIPTION
One day we need to deal with those but none are critical and they slow us down right now...