### PR TITLE
Make SuperDuperCursor Cachable

### DIFF
--- a/superduperdb/core/documents.py
+++ b/superduperdb/core/documents.py
@@ -5,7 +5,7 @@ import typing as t
 ContentType = t.Union[t.Dict, Encodable]
 
 
-class Document(Cached[ContentType]):
+class Document(Cached):
     """
     A wrapper around an instance of dict or a Encodable which may be used to dump
     that resource to a mix of jsonable content or `bytes`
@@ -30,7 +30,7 @@ class Document(Cached[ContentType]):
     @classmethod
     def decode(cls, r: t.Dict, types: t.Dict):
         if isinstance(r, Document):
-            return Document(cls._decode(r, types))
+            return Document(content=(cls._decode(r, types))
         elif isinstance(r, dict):
             return cls._decode(r, types)
         raise NotImplementedError(f'type {type(r)} is not supported')

--- a/superduperdb/datalayer/base/cursor.py
+++ b/superduperdb/datalayer/base/cursor.py
@@ -1,6 +1,6 @@
 import dataclasses as dc
 import typing as t
-from functools import cached_property, wraps
+from functools import cached_property
 from pymongo.cursor import Cursor
 from superduperdb.core.documents import Document
 from superduperdb.core.encoder import Encoder
@@ -9,9 +9,9 @@ from superduperdb.misc.uri_cache import Cached
 
 
 @dc.dataclass
-class _SuperDuperCursor:
-    raw_cursor: Cursor
-    id_field: str
+class SuperDuperCursor(Cached):
+    raw_cursor: Cursor = None
+    id_field: str = ''
     types: t.Dict[str, Encoder] = dc.field(default_factory=dict)
     features: t.Optional[t.Dict[str, str]] = None
     scores: t.Optional[t.Dict[str, float]] = None
@@ -24,6 +24,17 @@ class _SuperDuperCursor:
 
         return None if self.scores is None else sorted(self.raw_cursor, key=key)
 
+    @staticmethod
+    def add_features(r, features):
+        r = MongoStyleDict(r)
+        for k in features:
+            r[k] = r['_outputs'][k][features[k]]
+        if '_other' in r:
+            for k in features:
+                if k in r['_other']:
+                    r['_other'][k] = r['_outputs'][k][features[k]]
+        return r
+
     def limit(self, *args, **kwargs):
         return SuperDuperCursor(
             raw_cursor=self.raw_cursor.limit(*args, **kwargs),
@@ -32,6 +43,10 @@ class _SuperDuperCursor:
             features=self.features,
             scores=self.scores,
         )
+
+    @staticmethod
+    def wrap_document(r, types):
+        return Document(Document.decode(r, types))
 
     def __iter__(self):
         return self
@@ -48,33 +63,9 @@ class _SuperDuperCursor:
         if self.scores is not None:
             r['_score'] = self.scores[str(r[self.id_field])]
         if self.features is not None and self.features:
-            r = add_features(r, features=self.features)
+            r = self.add_features(r, features=self.features)
 
-        return wrap_document(r, self.types)
-
-
-class SuperDuperCursor(Cached[_SuperDuperCursor]):
-    @wraps(_SuperDuperCursor.__init__)
-    def __init__(self, *a, **ka):
-        super().__init__(_SuperDuperCursor(*a, **ka))
-
-    def __iter__(self):
-        return iter(self.content)
-
-    def __next__(self):
-        return next(self.content)
+        return self.wrap_document(r, self.types)
 
 
-def wrap_document(r, types) -> Document:
-    return Document(Document.decode(r, types))
-
-
-def add_features(r, features):
-    r = MongoStyleDict(r)
-    for k in features:
-        r[k] = r['_outputs'][k][features[k]]
-    if '_other' in r:
-        for k in features:
-            if k in r['_other']:
-                r['_other'][k] = r['_outputs'][k][features[k]]
-    return r
+SuperDuperCursor.erase_fields()

--- a/superduperdb/datalayer/base/database.py
+++ b/superduperdb/datalayer/base/database.py
@@ -164,7 +164,7 @@ class BaseDatabase:
         out = model.predict(input.unpack(), **opts.get('predict_kwargs', {}))
         if model.encoder is not None:
             out = model.encoder(out)  # type: ignore
-        return Document(out)
+        return Document(content=out)
 
     def execute(self, query: ExecuteQuery) -> ExecuteResult:
         """
@@ -558,7 +558,7 @@ class BaseDatabase:
             else:
                 select = query.select_using_ids(ids)
                 cursor = self.select(select).raw_cursor  # type: ignore[attr-defined]
-                documents = [Document(x) for x in cursor]
+                documents = [Document(content=x) for x in cursor]
         elif isinstance(query, Insert):
             documents = query.documents
         else:
@@ -614,7 +614,7 @@ class BaseDatabase:
 
     def _get_content_for_filter(self, filter) -> Document:
         if isinstance(filter, dict):
-            filter = Document(filter)
+            filter = Document(content=filter)
         if '_id' not in filter.content:
             filter['_id'] = 0
         uris = gather_uris([filter.content])[0]
@@ -622,7 +622,7 @@ class BaseDatabase:
             output = self._download_content(
                 query=None, documents=[filter.content], timeout=None, raises=True
             )[0]
-            filter = Document(Document.decode(output, types=self.types))
+            filter = Document(content=Document.decode(output, types=self.types))
         return filter
 
     def _get_dependencies_for_watcher(self, identifier):

--- a/superduperdb/misc/uri_cache.py
+++ b/superduperdb/misc/uri_cache.py
@@ -7,7 +7,6 @@ if t.TYPE_CHECKING:
 else:
     from . import dataclasses as dc
 
-
 ContentType = t.TypeVar('ContentType')
 
 
@@ -27,6 +26,15 @@ class Cached(t.Generic[ContentType]):
     def content(self, content: ContentType):
         """Set the cached content. `content` is not JSONized"""
         self._content = content  # type: ignore[return-value, attr-defined]
+
+    def __getattr__(self, k: str) -> t.Any:
+        return getattr(self.content, k)
+
+    def __setattr__(self, k: str, v: t.Any) -> None:
+        if k in ('_content', 'content', 'uri'):
+            super().__setattr__(k, v)
+        else:
+            setattr(self.content, k, v)
 
     def __post_init__(self, content: ContentType):
         self.content = content

--- a/superduperdb/misc/uri_cache.py
+++ b/superduperdb/misc/uri_cache.py
@@ -1,43 +1,23 @@
 from .for_each import for_each
 from .typed_cache import TypedCache
+from superduperdb.misc import dataclasses as dc
 import typing as t
-
-if t.TYPE_CHECKING:
-    import dataclasses as dc
-else:
-    from . import dataclasses as dc
 
 ContentType = t.TypeVar('ContentType')
 
 
 @dc.dataclass
-class Cached(t.Generic[ContentType]):
+class Cached:
     """A base class for classes that are cached using their uri and type"""
 
-    _content: dc.InitVar[ContentType] = None
     uri: str = ''
 
-    @property
-    def content(self) -> ContentType:
-        """Get the cached content. `content` is not JSONized"""
-        return self._content  # type: ignore[return-value, attr-defined]
+    @classmethod
+    def erase_fields(cls):
+        cls.__dataclass_fields__ = Cached.__dataclass_fields__
 
-    @content.setter
-    def content(self, content: ContentType):
-        """Set the cached content. `content` is not JSONized"""
-        self._content = content  # type: ignore[return-value, attr-defined]
-
-    def __getattr__(self, k: str) -> t.Any:
-        return getattr(self.content, k)
-
-    def __setattr__(self, k: str, v: t.Any) -> None:
-        if k in ('_content', 'content', 'uri'):
-            super().__setattr__(k, v)
-        else:
-            setattr(self.content, k, v)
-
-    def __post_init__(self, content: ContentType):
-        self.content = content
+    def __post_init__(self):
+        assert isinstance(self.url, str), 'uri must be a string'
 
 
 class URICache(TypedCache):

--- a/superduperdb/models/langchain/retriever.py
+++ b/superduperdb/models/langchain/retriever.py
@@ -33,7 +33,7 @@ class LangchainRetriever(BaseRetriever):
         self.n = n
 
     def get_relevant_documents(self, query: str) -> t.List[Document]:
-        document_to_search = documents.Document({self.key: query})
+        document_to_search = documents.Document(content={self.key: query})
         ids, scores = self.vector_index.get_nearest(
             document_to_search,
             n=self.n,

--- a/superduperdb/queries/mongodb/queries.py
+++ b/superduperdb/queries/mongodb/queries.py
@@ -5,7 +5,11 @@ import random
 import typing as t
 
 from superduperdb.core.documents import Document
-from superduperdb.datalayer.base.cursor import SuperDuperCursor
+from superduperdb.datalayer.base.cursor import (
+    SuperDuperCursor,
+    add_features,
+    wrap_document,
+)
 from superduperdb.datalayer.base.database import BaseDatabase
 from superduperdb.datalayer.base.query import Select, SelectOne, Insert, Delete, Update
 from superduperdb.datalayer.base.query import Like
@@ -278,7 +282,7 @@ class FeaturizeOne(SelectOne):
 
     def __call__(self, db: BaseDatabase):
         r = self.parent_find_one(db)
-        r = SuperDuperCursor.add_features(r.content, self.features)
+        r = add_features(r.content, self.features)
         return Document(r)
 
 
@@ -292,7 +296,7 @@ class FindOne(SelectOne):
 
     def __call__(self, db: BaseDatabase):
         if self.collection is not None:
-            return SuperDuperCursor.wrap_document(
+            return wrap_document(
                 db.db[self.collection.name].find_one(*self.args, **self.kwargs),
                 types=db.types,
             )

--- a/tests/unittests/misc/test_dataclasses.py
+++ b/tests/unittests/misc/test_dataclasses.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 from superduperdb.misc import dataclasses as dc
+import dataclasses
 
 
 @dc.dataclass
@@ -59,3 +60,24 @@ def test_dataclasses():
 
 def test_methods():
     assert [f.name for f in Un.fields()] == ['un', 'nine', 'ten']
+
+
+@dc.dataclass
+class Cached:
+    suri: str = ''
+
+
+@dataclasses.dataclass
+class Data(Cached):
+    a: bytes = bytes()
+    b: str = ''
+    c: int = 3
+
+
+Data.__dataclass_fields__ = Cached.__dataclass_fields__
+
+
+def test_filtered_classes():
+    d = Data(a=bytes(range(3)), b='b', c=12)
+    assert d.dict() == {'suri': ''}
+    assert d.c == 12

--- a/tests/unittests/misc/test_uri_cache.py
+++ b/tests/unittests/misc/test_uri_cache.py
@@ -4,12 +4,12 @@ from superduperdb.misc import dataclasses as dc
 from superduperdb.misc import uri_cache
 
 
-class Str(uri_cache.Cached[str]):
+class Str(uri_cache.Cached):
     def __hash__(self):
         return object.__hash__(self)
 
 
-class Tuple(uri_cache.Cached[tuple]):
+class Tuple(uri_cache.Cached):
     def __hash__(self):
         return object.__hash__(self)
 


### PR DESCRIPTION
I pulled this out of a longer branch, https://github.com/rec/superduperdb-stealth/commits/server-9

You should be able to make almost everything cachable this way.

Note that you have to forward the `__iter__` and `__next__`  methods "by hand".