### PR TITLE
PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Provide a brief description of the changes introduced by this pull request -->
+<!-- If adding a new feature, please describe the intended way of using this feature as clearly as possible -->
+
+## Related Issue(s)
+
+<!-- If your pull request is related to any GitHub issue(s), mention them here with the appropriate links -->
+
+## Checklist
+
+<!-- Mark the tasks that are completed. You can add or remove items as necessary -->
+
+- [ ] Change or addition is covered by unit and/or integration tests. If bugfix, there should be at least one test that fails pre-PR and passes after.
+- [ ] Classes and functions substantially affected by this PR have `sphinx` format docstrings added or updated.
+- [ ] If your changes introduce modifications to functionality, behavior, or usage of the project, please ensure that the documentation is updated accordingly.
+<!-- Update relevant sections such as README files and user guides to help users understand the changes and how to use the updated features. -->
+
+## Additional Notes
+
+<!-- Add any additional notes, comments, or explanations that may be helpful to the reviewers -->
+
+
+


### PR DESCRIPTION
## What it is

A template that will automatically populate a user's PR message when they open a PR.

## Why do we need this

- to support users unclear of what needs to be done before opening a PR
- to support maintainers by quickly identifying what the PR does (templates can reduce cognitive overhead)

## How it's implemented

I have re-used a template from past work. I have limited OSS experience so this template can perhaps be edited to a format more effective for OSS.