### PR TITLE
Refactor `isinstance` checks to allow use of TypeGuard

### DIFF
--- a/superduperdb/core/base.py
+++ b/superduperdb/core/base.py
@@ -1,9 +1,10 @@
 # ruff: noqa: F821
+import typing as t
 from collections import defaultdict
 from contextlib import contextmanager
-import typing as t
 
 from dask.distributed import Future
+from typing_extensions import TypeGuard
 
 from superduperdb.core.job import ComponentJob
 from superduperdb.misc.logger import logging
@@ -391,11 +392,15 @@ def restore(component: t.Union[BaseComponent, BasePlaceholder], cache: t.Dict):
     return component
 
 
-def is_placeholders_or_components(items: t.Union[t.List[t.Any], t.Tuple]):
-    """
-    Test whether the list is just strings and also test whether it's just components
-    """
+def is_str_list(items: t.Union[t.List[t.Any], t.Tuple]) -> TypeGuard[t.List[str]]:
+    if isinstance(items, t.List):
+        return all([isinstance(y, str) for y in items])
+    return False
 
-    is_placeholders = all([isinstance(y, str) for y in items])
-    is_components = all([isinstance(y, Component) for y in items])
-    return is_placeholders, is_components
+
+def is_component_list(
+    items: t.Union[t.List[t.Any], t.Tuple]
+) -> TypeGuard[t.List[Component]]:
+    if isinstance(items, t.List):
+        return all([isinstance(y, Component) for y in items])
+    return False

--- a/superduperdb/core/fit.py
+++ b/superduperdb/core/fit.py
@@ -5,7 +5,8 @@ from superduperdb.core.base import (
     ComponentList,
     Placeholder,
     PlaceholderList,
-    is_placeholders_or_components,
+    is_component_list,
+    is_str_list,
 )
 from superduperdb.core.metric import Metric
 from superduperdb.core.model import Model, ModelEnsemble, TrainingConfiguration
@@ -52,21 +53,21 @@ class Fit(Component):
         else:
             assert isinstance(model, Model)
 
-        err_msg = 'Must specify all metric IDs or all Metric instances directly'
-        metrics_are_strs, metrics_are_comps = is_placeholders_or_components(metrics)
-        assert metrics_are_strs or metrics_are_comps, err_msg
-
-        if metrics_are_strs:
-            self.metrics = PlaceholderList('metric', metrics)  # type: ignore[arg-type]
+        if is_str_list(metrics):
+            self.metrics = PlaceholderList('metric', metrics)
+        elif is_component_list(metrics):
+            self.metrics = ComponentList('metric', metrics)
         else:
-            self.metrics = ComponentList('metric', metrics)  # type: ignore[arg-type]
+            raise TypeError(
+                f'Fit.metrics must be list of strings or Components, got {metrics} '
+            )
 
         self.keys = keys
         # ruff: noqa: E501
         self.training_configuration = (
             training_configuration
             if isinstance(training_configuration, TrainingConfiguration)
-            else Placeholder(training_configuration, 'training_configuration')  # type: ignore[arg-type]
+            else Placeholder(training_configuration, 'training_configuration')
         )
         self.identifier = identifier
         self.validation_sets = validation_sets

--- a/superduperdb/core/vector_index.py
+++ b/superduperdb/core/vector_index.py
@@ -8,7 +8,8 @@ from superduperdb.core.base import (
     DBPlaceholder,
     Placeholder,
     PlaceholderList,
-    is_placeholders_or_components,
+    is_component_list,
+    is_str_list,
 )
 from superduperdb.core.dataset import Dataset
 from superduperdb.core.documents import Document
@@ -79,17 +80,15 @@ class VectorIndex(Component):
 
         self.compatible_watchers = ()
         if compatible_watchers:
-            is_placeholders, is_components = is_placeholders_or_components(
-                compatible_watchers
-            )
-            assert is_placeholders or is_components
-            if is_placeholders:
+            if is_str_list(compatible_watchers):
                 self.compatible_watchers = PlaceholderList(
-                    'watcher', compatible_watchers  # type: ignore[arg-type]
+                    'watcher', compatible_watchers
                 )
+            elif is_component_list(compatible_watchers):
+                self.compatible_watchers = ComponentList('watcher', compatible_watchers)
             else:
-                self.compatible_watchers = ComponentList(
-                    'watcher', t.cast(t.List[Component], compatible_watchers)
+                raise TypeError(
+                    f'VectorIndex.compatible_watchers must be list of strings or Components, got {compatible_watchers} '
                 )
         self.measure = measure
         self.database = DBPlaceholder()


### PR DESCRIPTION
I have refactored `is_placeholders_or_components` to allow use of `TypeGuard`. This allows us to remove some `mypy` ignore statements elsewhere in the code, and improves readability (IMO).

Note that I have added extra logic to confirm that it is a `List` that we are dealing with - classes like `ComponentList` have `__setitem__` defined on them, which would cause a 💥 if it were a `Tuple`(the other currently allowed type).

I struggled with a sensible error message. Suggestions welcome.