### PR TITLE
Fix cdc integration test

### DIFF
--- a/tests/integration/test_cdc.py
+++ b/tests/integration/test_cdc.py
@@ -115,7 +115,6 @@ class TestMongoCDC:
         watch_fixture.stop()
         assert info['updates'] == count
 
-    @pytest.mark.skip('Broken')
     @patch('superduperdb.datalayer.mongodb.cdc.copy_vectors')
     def test_task_workflow_on_insert(
         self, mocked_copy_vectors, watch_fixture, with_vector_index, a_single_insert
@@ -132,12 +131,9 @@ class TestMongoCDC:
         output, _ = with_vector_index.execute(
             Collection(name='documents').insert_many([a_single_insert], refresh=False)
         )
-        time.sleep(4)
+        time.sleep(3)
         _id = output.inserted_ids[0]
         doc = with_vector_index.db['documents'].find_one({'_id': _id})
-        import pdb
-
-        pdb.set_trace()
         watch_fixture.stop()
         assert '_outputs' in doc.keys()
         assert 'linear_a' in doc['_outputs']['x'].keys()


### PR DESCRIPTION
resolves #392 bug by removing backfill function from vector_index class in core.vector_index

for more details visit:
#392 

