### PR TITLE
Fix distributed execution of taskgraph on dask

### DIFF
--- a/superduperdb/__init__.py
+++ b/superduperdb/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 __all__ = 'CFG', 'ICON', 'JSONable', 'ROOT', 'config', 'log'
 
-CFG = configs.CONFIG.config
+CFG = configs.build_config()
 ICON = '🔮'
 ROOT = Path(__file__).parent
 

--- a/superduperdb/cluster/dask/dask_client.py
+++ b/superduperdb/cluster/dask/dask_client.py
@@ -1,10 +1,45 @@
-from dask.distributed import Client
-from superduperdb import CFG
+import uuid
+
+from dask.distributed import Client, wait, fire_and_forget
+
+from superduperdb.misc.logger import logging
 
 
-def dask_client():
-    return Client(
-        address=f'tcp://{CFG.dask.ip}:{CFG.dask.port}',
-        serializers=CFG.dask.serializers,
-        deserializers=CFG.dask.deserializers,
+class DaskClient:
+    def __init__(self, address: str, serializers=None, deserializers=None):
+        self.futures_collection = {}
+        self.client = Client(
+            address=address,
+            serializers=serializers,
+            deserializers=deserializers,
+        )
+
+    def submit(self, function, **kwargs):
+        future = self.client.submit(function, **kwargs)
+        identifier = kwargs.get('identifier', None)
+        if not identifier:
+            logging.warning('Could not get an identifier from submitted function, creating one!')
+            identifier = str(uuid.uuid4())
+        self.futures_collection[identifier] = future
+        return future
+
+    def submit_and_forget(self, function, **kwargs):
+        future = self.submit(function, **kwargs)
+        fire_and_forget(future)
+        return future
+
+    def wait_all_pending_task(self):
+        futures = self.futures_collection.values()
+        wait(futures)
+
+    def get_result(self, identifier: str):
+        future = self.futures_collection[identifier]
+        return self.client.gather(future)
+
+
+def dask_client(cfg):
+    return DaskClient(
+        address=f'tcp://{cfg.ip}:{cfg.port}',
+        serializers=cfg.serializers,
+        deserializers=cfg.deserializers,
     )

--- a/superduperdb/cluster/dask/dask_client.py
+++ b/superduperdb/cluster/dask/dask_client.py
@@ -1,24 +1,31 @@
 import uuid
 
+from dask.distributed import LocalCluster
 from dask.distributed import Client, wait, fire_and_forget
 
 from superduperdb.misc.logger import logging
 
 
 class DaskClient:
-    def __init__(self, address: str, serializers=None, deserializers=None):
+    def __init__(self, address: str, serializers=None, deserializers=None, local=False):
         self.futures_collection = {}
-        self.client = Client(
-            address=address,
-            serializers=serializers,
-            deserializers=deserializers,
-        )
+        if local:
+            cluster = LocalCluster(n_workers=1)
+            self.client = Client(cluster)
+        else:
+            self.client = Client(
+                address=address,
+                serializers=serializers,
+                deserializers=deserializers,
+            )
 
     def submit(self, function, **kwargs):
         future = self.client.submit(function, **kwargs)
         identifier = kwargs.get('identifier', None)
         if not identifier:
-            logging.warning('Could not get an identifier from submitted function, creating one!')
+            logging.warning(
+                'Could not get an identifier from submitted function, creating one!'
+            )
             identifier = str(uuid.uuid4())
         self.futures_collection[identifier] = future
         return future
@@ -28,8 +35,11 @@ class DaskClient:
         fire_and_forget(future)
         return future
 
-    def wait_all_pending_task(self):
-        futures = self.futures_collection.values()
+    def shutdown(self):
+        self.client.shutdown()
+
+    def wait_all_pending_tasks(self):
+        futures = list(self.futures_collection.values())
         wait(futures)
 
     def get_result(self, identifier: str):
@@ -37,9 +47,10 @@ class DaskClient:
         return self.client.gather(future)
 
 
-def dask_client(cfg):
+def dask_client(cfg, local=False):
     return DaskClient(
         address=f'tcp://{cfg.ip}:{cfg.port}',
         serializers=cfg.serializers,
         deserializers=cfg.deserializers,
+        local=local,
     )

--- a/superduperdb/cluster/vector_search.py
+++ b/superduperdb/cluster/vector_search.py
@@ -27,7 +27,7 @@ database = build_datalayer()
 @maybe_login_required(auth, 'vector_search')
 def serve():
     data = BSON.decode(request.get_data())
-    database.remote = False
+    database.distributed = False
     method = getattr(database, data['method'])
     result = method.f(database, *data['args'], **data['kwargs'])
     logging.info('results')

--- a/superduperdb/core/component.py
+++ b/superduperdb/core/component.py
@@ -35,7 +35,7 @@ class Component(Serializable):
             method_name='predict',
             variety='model',
             kwargs={
-                'remote': False,
+                'distributed': False,
                 'validation_set': validation_set,
                 'metrics': metrics,
             },
@@ -56,7 +56,7 @@ class Component(Serializable):
         db: 'superduperdb.datalayer.base.database.Database',  # type: ignore[name-defined]
         validation_set: t.Union[str, 'Dataset'],  # type: ignore[name-defined]
         metrics: t.List[t.Union['Metric', str]],  # type: ignore[name-defined]
-        remote: bool = False,
+        distributed: bool = False,
         dependencies: t.Sequence[Future] = (),
     ):
         from .dataset import Dataset
@@ -73,11 +73,11 @@ class Component(Serializable):
                 db.add(m)
                 metrics[i] = m.identifier
 
-        if remote:
+        if distributed:
             return self.create_validation_job(
                 validation_set=validation_set,
                 metrics=metrics,
-            )(db=db, remote=True, dependencies=dependencies)
+            )(db=db, distributed=True, dependencies=dependencies)
 
         output = self._validate(
             db=db,

--- a/superduperdb/core/job.py
+++ b/superduperdb/core/job.py
@@ -79,7 +79,7 @@ class FunctionJob(Job):
         return d
 
     def run_on_dask(self, client, dependencies=()):
-        future = client.submit(
+        future = client.submit_and_forget(
             callable_job,
             function_to_call=self.callable,
             job_id=self.identifier,
@@ -129,8 +129,8 @@ class ComponentJob(Job):
         self._component = value
         self.callable = getattr(self._component, self.method_name)
 
-    def run_on_dask(self,client, dependencies=()):
-        future = client.submit(
+    def run_on_dask(self, client, dependencies=()):
+        future = client.submit_and_forget(
             method_job,
             variety=self.variety,
             identifier=self.component_identifier,

--- a/superduperdb/core/model.py
+++ b/superduperdb/core/model.py
@@ -116,7 +116,7 @@ class Model(Component):
             variety='model',
             args=[X],
             kwargs={
-                'remote': False,
+                'distributed': False,
                 'select': to_dict(select) if select else None,
                 'ids': ids,
                 'max_chunk_size': max_chunk_size,
@@ -138,7 +138,7 @@ class Model(Component):
             args=[X],
             kwargs={
                 'y': y,
-                'remote': False,
+                'distributed': False,
                 'select': to_dict(select) if select else None,
                 **kwargs,
             },
@@ -164,7 +164,7 @@ class Model(Component):
         y: t.Optional[t.Any] = None,
         db: t.Optional['BaseDatabase'] = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
-        remote: bool = False,
+        distributed: bool = False,
         dependencies: t.List[Job] = (),  # type: ignore[assignment]
         configuration: t.Optional[_TrainingConfiguration] = None,
         validation_sets: t.Optional[t.List[t.Union[str, Dataset]]] = None,
@@ -184,13 +184,13 @@ class Model(Component):
         if db is not None:
             db.add(self)
 
-        if remote:
+        if distributed:
             return self.create_fit_job(
                 X,
                 select=select,
                 y=y,
                 **kwargs,
-            )(db=db, remote=True, dependencies=dependencies)
+            )(db=db, distributed=True, dependencies=dependencies)
         else:
             return self._fit(
                 X,
@@ -209,7 +209,7 @@ class Model(Component):
         X: t.Any,
         db: 'BaseDatabase' = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
-        remote: bool = False,
+        distributed: bool = False,
         ids: t.Optional[t.List[str]] = None,
         max_chunk_size: t.Optional[int] = None,
         dependencies: t.List[Job] = (),  # type: ignore[assignment]
@@ -234,10 +234,10 @@ class Model(Component):
         if db is not None:
             db.add(self)
 
-        if remote:
+        if distributed:
             return self.create_predict_job(
                 X, select=select, ids=ids, max_chunk_size=max_chunk_size, **kwargs
-            )(db=db, remote=remote, dependencies=dependencies)
+            )(db=db, distributed=distributed, dependencies=dependencies)
         else:
             if select is not None and ids is None:
                 ids = [
@@ -248,7 +248,7 @@ class Model(Component):
                     X=X,
                     db=db,
                     ids=ids,
-                    remote=False,
+                    distributed=False,
                     select=select,
                     max_chunk_size=max_chunk_size,
                     **kwargs,
@@ -261,7 +261,7 @@ class Model(Component):
                 else:
                     X_data = [r.unpack() for r in docs]
 
-                outputs = self.predict(X=X_data, remote=False)
+                outputs = self.predict(X=X_data, distributed=False)
                 if self.encoder is not None:
                     # ruff: noqa: E501
                     outputs = [self.encoder(x).encode() for x in outputs]  # type: ignore[operator]
@@ -337,7 +337,7 @@ class ModelEnsemble(Component):
         y: t.Optional[t.Any] = None,
         db: t.Optional['BaseDatabase'] = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
-        remote: bool = False,
+        distributed: bool = False,
         dependencies: t.List[Job] = (),  # type: ignore[assignment]
         configuration: t.Optional[_TrainingConfiguration] = None,
         validation_sets: t.Optional[t.List[t.Union[str, Dataset]]] = None,
@@ -357,13 +357,13 @@ class ModelEnsemble(Component):
         if db is not None:
             db.add(self)
 
-        if remote:
+        if distributed:
             return self.create_fit_job(
                 X,
                 select=select,
                 y=y,
                 **kwargs,
-            )(db=db, remote=True, dependencies=dependencies)
+            )(db=db, distributed=True, dependencies=dependencies)
         else:
             return self._fit(
                 X,

--- a/superduperdb/core/task_workflow.py
+++ b/superduperdb/core/task_workflow.py
@@ -20,13 +20,15 @@ class TaskWorkflow:
     def dependencies(self, node):
         return [self.G.nodes[a]['job'].future for a in self.G.predecessors(node)]
 
-    def __call__(self, db=None, remote: bool = False):
+    def __call__(self, db=None, distributed: bool = False):
         current_group = [n for n in self.G.nodes if not networkx.ancestors(self.G, n)]
         done = []
         while current_group:
             for node in current_group:
                 job: Job = self.G.nodes[node]['job']
-                job(db=db, dependencies=self.dependencies(node), remote=remote)
+                job(
+                    db=db, dependencies=self.dependencies(node), distributed=distributed
+                )
                 done.append(node)
 
             current_group = [

--- a/superduperdb/core/tasks.py
+++ b/superduperdb/core/tasks.py
@@ -51,7 +51,7 @@ class Logger:
 def handle_function_output(function, db, job_id, args, kwargs):
     with contextlib.redirect_stdout(Logger(db, job_id)):
         with contextlib.redirect_stderr(Logger(db, job_id, stream='stderr')):
-            return function(db, *args, **kwargs)
+            return function(db=db, *args, **kwargs)
 
 
 def callable_job(
@@ -62,7 +62,6 @@ def callable_job(
     dependencies=(),
 ):
     from superduperdb.datalayer.base.build import build_datalayer
-
     db = build_datalayer()
     db.metadata.update_job(job_id, 'status', 'running')
     try:

--- a/superduperdb/core/tasks.py
+++ b/superduperdb/core/tasks.py
@@ -3,6 +3,7 @@ import traceback
 
 
 def method_job(
+    cfg,
     variety,
     identifier,
     method_name,
@@ -13,7 +14,7 @@ def method_job(
 ):
     from superduperdb.datalayer.base.build import build_datalayer
 
-    db = build_datalayer()
+    db = build_datalayer(cfg)
     component = db.load(variety, identifier)
     method = getattr(component, method_name)
     db.metadata.update_job(job_id, 'status', 'running')
@@ -55,6 +56,7 @@ def handle_function_output(function, db, job_id, args, kwargs):
 
 
 def callable_job(
+    cfg,
     function_to_call,
     args,
     kwargs,
@@ -63,7 +65,7 @@ def callable_job(
 ):
     from superduperdb.datalayer.base.build import build_datalayer
 
-    db = build_datalayer()
+    db = build_datalayer(cfg)
     db.metadata.update_job(job_id, 'status', 'running')
     try:
         handle_function_output(

--- a/superduperdb/core/tasks.py
+++ b/superduperdb/core/tasks.py
@@ -62,6 +62,7 @@ def callable_job(
     dependencies=(),
 ):
     from superduperdb.datalayer.base.build import build_datalayer
+
     db = build_datalayer()
     db.metadata.update_job(job_id, 'status', 'running')
     try:

--- a/superduperdb/core/watcher.py
+++ b/superduperdb/core/watcher.py
@@ -41,14 +41,16 @@ class Watcher(Component):
     def cleanup(self, database) -> None:
         self.select.model_cleanup(database, model=self.model.identifier, key=self.key)
 
-    def schedule_jobs(self, database, verbose=False, dependencies=(), remote=False):
+    def schedule_jobs(
+        self, database, verbose=False, dependencies=(), distributed=False
+    ):
         if not self.active:
             return
         return self.model.predict(
             X=self.key,
             db=database,
             select=self.select,
-            remote=remote,
+            distributed=distributed,
             max_chunk_size=self.max_chunk_size,
             dependencies=dependencies,
         )

--- a/superduperdb/datalayer/base/build.py
+++ b/superduperdb/datalayer/base/build.py
@@ -1,5 +1,3 @@
-import pymongo
-
 from superduperdb import CFG
 from superduperdb.datalayer.base.backends import (
     data_backends,
@@ -50,5 +48,5 @@ def build_datalayer(**connections) -> BaseDatabase:
         vector_database=build_vector_database(
             CFG.vector_search.type, vector_database_stores
         ),
-        distributed_client=build_distributed_client(CFG)
+        distributed_client=build_distributed_client(CFG),
     )

--- a/superduperdb/datalayer/base/database.py
+++ b/superduperdb/datalayer/base/database.py
@@ -84,7 +84,7 @@ class BaseDatabase:
         self.encoders = LoadDict(self, 'encoder')
         self.vector_indices = LoadDict(self, 'vector_index')
 
-        self.remote = CFG.remote
+        self.distributed = CFG.distributed
         self.metadata = metadata
         self.artifact_store = artifact_store
         self.databackend = databackend
@@ -216,7 +216,7 @@ class BaseDatabase:
         self,
         job,
         depends_on: t.Optional[t.List[Future]] = None,
-        remote: t.Optional[bool] = None,
+        distributed: t.Optional[bool] = None,
     ):
         """
         Run job. See ``core.job.Job``, ``core.job.FunctionJob``, ``core.job.ComponentJob``.
@@ -224,9 +224,9 @@ class BaseDatabase:
         :param job:
         :param depends_on: List of dependencies
         """
-        if remote is None:
-            remote = CFG.remote
-        return job(db=self, dependencies=depends_on, remote=remote)
+        if distributed is None:
+            distributed = CFG.distributed
+        return job(db=self, dependencies=depends_on, distributed=distributed)
 
     def select(self, select: Select) -> SelectResult:
         """
@@ -267,7 +267,7 @@ class BaseDatabase:
             ids=ids,
             verbose=verbose,
         )
-        task_graph(db=self, remote=self.remote)
+        task_graph(db=self, distributed=self.distributed)
         return task_graph
 
     def update(self, update: Update) -> UpdateResult:
@@ -708,7 +708,7 @@ class BaseDatabase:
                     model=model,
                     recompute=recompute,
                     watcher_info=watcher_info,
-                    remote=False,
+                    distributed=False,
                     **kwargs,
                 )
             return []

--- a/superduperdb/datalayer/base/database.py
+++ b/superduperdb/datalayer/base/database.py
@@ -77,7 +77,7 @@ class BaseDatabase:
         metadata: MetaDataStore,
         artifact_store: ArtifactStore,
         vector_database: VectorDatabase,
-        distributed_client = None
+        distributed_client=None,
     ):
         self.metrics = LoadDict(self, 'metric')
         self.models = LoadDict(self, 'model')

--- a/superduperdb/datalayer/mongodb/cdc.py
+++ b/superduperdb/datalayer/mongodb/cdc.py
@@ -179,7 +179,7 @@ def copy_vectors(
         table.add(vectors, upsert=True)
     except Exception:
         logging.exception(
-            f"Error while copying vectors for `vector_index`: {indexing_watcher_identifier}"  # noqa: E501
+            f"Error while copying vectors for `vector_index`: {indexing_watcher_identifier}"
         )
         raise
 

--- a/superduperdb/datalayer/mongodb/cdc.py
+++ b/superduperdb/datalayer/mongodb/cdc.py
@@ -179,7 +179,7 @@ def copy_vectors(
         table.add(vectors, upsert=True)
     except Exception:
         logging.exception(
-            f"Error while copying vectors for `vector_index`: {indexing_watcher_identifier}"
+            f"Error in copying_vectors for vector_index: {indexing_watcher_identifier}"
         )
         raise
 
@@ -249,21 +249,16 @@ class CDCHandler(threading.Thread):
         :rtype: TaskWorkflow
         """
         for identifier in self.db.show('vector_index'):
-            vector_index = self.db.load(
-                identifier=identifier,
-                variety='vector_index',
-                init_db=False,
-            )
+            vector_index = self.db.load(identifier=identifier, variety='vector_index')
             vector_index = t.cast(VectorIndex, vector_index)
             indexing_watcher_identifier = vector_index.indexing_watcher.identifier
             task_graph.add_node(
                 f'copy_vectors({indexing_watcher_identifier})',
                 FunctionJob(
                     callable=copy_vectors,
-                    # BROKEN: the arguments in `args` are in the wrong order.
                     # BROKEN: cdc_query has its own ``to_dict`` method which
                     # probably should be called here.
-                    args=[indexing_watcher_identifier, ids, to_dict(cdc_query)],
+                    args=[indexing_watcher_identifier, to_dict(cdc_query), ids],
                     kwargs={},
                 ),
             )

--- a/superduperdb/datalayer/mongodb/metadata.py
+++ b/superduperdb/datalayer/mongodb/metadata.py
@@ -192,10 +192,6 @@ class MongoMetaDataStore(MetaDataStore):
                     'version': version,
                 },
             )
-        if r is None:
-            import pdb
-
-            pdb.set_trace()
         return r
 
     def get_component_version_parents(self, unique_id: str):

--- a/superduperdb/misc/config.py
+++ b/superduperdb/misc/config.py
@@ -87,7 +87,10 @@ class ModelServer(HostPort):
 
 
 class MongoDB(HostPort):
-    port: str = 27017
+    port: str = 27018
+    host: str = 'localhost'
+    username: str = 'testmongodbuser'
+    password: str = 'testmongodbpassword'
 
 
 class DataLayer(JSONable):
@@ -180,6 +183,7 @@ class Config(JSONable):
     data_layers: DataLayers = Factory(DataLayers)
     notebook: Notebook = Factory(Notebook)
     ray: Ray = Factory(Ray)
+    remote: bool = False
     distributed: bool = False
     cdc: bool = False
     server: Server = Factory(Server)

--- a/superduperdb/misc/config.py
+++ b/superduperdb/misc/config.py
@@ -87,7 +87,7 @@ class ModelServer(HostPort):
 
 
 class MongoDB(HostPort):
-    port: str = 27018
+    port: int = 27017
     host: str = 'localhost'
     username: str = 'testmongodbuser'
     password: str = 'testmongodbpassword'
@@ -183,7 +183,6 @@ class Config(JSONable):
     data_layers: DataLayers = Factory(DataLayers)
     notebook: Notebook = Factory(Notebook)
     ray: Ray = Factory(Ray)
-    remote: bool = False
     distributed: bool = False
     cdc: bool = False
     server: Server = Factory(Server)

--- a/superduperdb/misc/configs.py
+++ b/superduperdb/misc/configs.py
@@ -45,4 +45,6 @@ class ConfigSettings:
         return self.cls(**dicts.combine((*data, environ_dict)))
 
 
-CONFIG = ConfigSettings(config.Config, ALL_CONFIGS, PREFIX)
+def build_config():
+    CONFIG = ConfigSettings(config.Config, ALL_CONFIGS, PREFIX)
+    return CONFIG.config

--- a/superduperdb/misc/superduper.py
+++ b/superduperdb/misc/superduper.py
@@ -42,7 +42,7 @@ def superduper(item, **kwargs):
             metadata=MongoMetaDataStore(conn=item.client, name=item.name),
             artifact_store=MongoArtifactStore(
                 conn=item.client, name=f'_filesystem:{item.name}'
-            )
+            ),
         )
     elif duck_type_sklearn(item):
         from sklearn.pipeline import Pipeline as BasePipeline

--- a/superduperdb/misc/superduper.py
+++ b/superduperdb/misc/superduper.py
@@ -42,7 +42,7 @@ def superduper(item, **kwargs):
             metadata=MongoMetaDataStore(conn=item.client, name=item.name),
             artifact_store=MongoArtifactStore(
                 conn=item.client, name=f'_filesystem:{item.name}'
-            ),
+            )
         )
     elif duck_type_sklearn(item):
         from sklearn.pipeline import Pipeline as BasePipeline

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,9 +67,9 @@ def test_db(mongodb_server: MongoDBConfig) -> Iterator[BaseDatabase]:
 def config(mongodb_server: MongoDBConfig) -> Iterator[None]:
     kwargs = asdict(TestMongoDBConfig())
     data_layers_cfg = DataLayers(
-        artifact=DataLayer(name='_filesystem:test_db', kwargs=kwargs),
-        data_backend=DataLayer(name='test_db', kwargs=kwargs),
-        metadata=DataLayer(name='test_db', kwargs=kwargs),
+        artifact=DataLayer(name='_filesystem:documents', kwargs=kwargs),
+        data_backend=DataLayer(name='documents', kwargs=kwargs),
+        metadata=DataLayer(name='documents', kwargs=kwargs),
     )
 
     with mock.patch('superduperdb.CFG.data_layers', data_layers_cfg):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,9 +67,9 @@ def test_db(mongodb_server: MongoDBConfig) -> Iterator[BaseDatabase]:
 def config(mongodb_server: MongoDBConfig) -> Iterator[None]:
     kwargs = asdict(TestMongoDBConfig())
     data_layers_cfg = DataLayers(
-        artifact=DataLayer(name='_filesystem:documents', kwargs=kwargs),
-        data_backend=DataLayer(name='documents', kwargs=kwargs),
-        metadata=DataLayer(name='documents', kwargs=kwargs),
+        artifact=DataLayer(name='_filesystem:test_db', kwargs=kwargs),
+        data_backend=DataLayer(name='test_db', kwargs=kwargs),
+        metadata=DataLayer(name='test_db', kwargs=kwargs),
     )
 
     with mock.patch('superduperdb.CFG.data_layers', data_layers_cfg):
@@ -353,7 +353,7 @@ def a_model_base(float_tensors_32, float_tensors_16):
 
 @pytest.fixture()
 def a_watcher(a_model):
-    a_model.remote = False
+    a_model.distributed = False
     a_model.add(
         Watcher(
             model='linear_a',

--- a/tests/integration/test_cdc.py
+++ b/tests/integration/test_cdc.py
@@ -35,15 +35,16 @@ class TestMongoCDC:
         with_vector_index.execute(
             Collection(name='documents').insert_many([a_single_insert])
         )
-        time.sleep(2)
-        info = watch_fixture.info()
+        time.sleep(1)
         watch_fixture.stop()
+        info = watch_fixture.info()
         assert info['inserts'] == 1
 
     def test_many_insert(self, watch_fixture, with_vector_index, an_insert):
         watch_fixture._cdc_change_handler = MagicMock()
         watch_fixture.watch()
         with_vector_index.execute(Collection(name='documents').insert_many(an_insert))
+        time.sleep(2)
         info = watch_fixture.info()
         watch_fixture.stop()
         assert info['inserts'] == len(an_insert)

--- a/tests/integration/test_cdc.py
+++ b/tests/integration/test_cdc.py
@@ -44,7 +44,6 @@ class TestMongoCDC:
         watch_fixture._cdc_change_handler = MagicMock()
         watch_fixture.watch()
         with_vector_index.execute(Collection(name='documents').insert_many(an_insert))
-        time.sleep(3)
         info = watch_fixture.info()
         watch_fixture.stop()
         assert info['inserts'] == len(an_insert)

--- a/tests/integration/test_cdc.py
+++ b/tests/integration/test_cdc.py
@@ -92,7 +92,6 @@ class TestMongoCDC:
         watch_fixture.stop()
         assert info['updates'] == count
 
-    @pytest.mark.skip('Broken')
     @patch('superduperdb.datalayer.mongodb.cdc.copy_vectors')
     def test_task_workflow_on_insert(
         self, mocked_copy_vectors, watch_fixture, with_vector_index, a_single_insert
@@ -112,9 +111,6 @@ class TestMongoCDC:
         time.sleep(4)
         _id = output.inserted_ids[0]
         doc = with_vector_index.db['documents'].find_one({'_id': _id})
-        import pdb
-
-        pdb.set_trace()
         watch_fixture.stop()
         assert '_outputs' in doc.keys()
         assert 'linear_a' in doc['_outputs']['x'].keys()

--- a/tests/integration/test_dask.py
+++ b/tests/integration/test_dask.py
@@ -1,0 +1,34 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from superduperdb.datalayer.mongodb.query import Collection
+from superduperdb.cluster.dask.dask_client import dask_client
+
+
+def test_taskgraph_futures_with_dask(random_data, a_watcher, an_update):
+    from superduperdb.misc.configs import CONFIG
+    with patch.object(CONFIG.config, "remote", True):
+        random_data.remote = True
+        client = dask_client(CONFIG.config.dask)
+        random_data._distributed_client = client
+        output, graph = random_data.execute(Collection(name='documents').insert_many(an_update))
+
+    client.wait_all_pending_task()
+    time.sleep(3)
+    nodes = graph.G.nodes
+    jobs = [nodes[node]['job'] for node in nodes]
+    assert all([job.future.status == 'finished' for job in jobs])
+
+def test_insert_with_dask(random_data, a_watcher, an_update):
+    from superduperdb.misc.configs import CONFIG
+    with patch.object(CONFIG.config, "remote", True):
+        random_data.remote = True
+        client = dask_client(CONFIG.config.dask)
+        random_data._distributed_client = client
+        random_data.execute(Collection(name='documents').insert_many(an_update))
+        time.sleep(3)
+        r = next(random_data.execute(Collection(name='documents').find({'update': True})))
+        assert 'linear_a' in r['_outputs']['x']
+

--- a/tests/integration/test_dask.py
+++ b/tests/integration/test_dask.py
@@ -1,4 +1,3 @@
-import time
 from unittest.mock import patch
 
 import pytest
@@ -7,28 +6,43 @@ from superduperdb.datalayer.mongodb.query import Collection
 from superduperdb.cluster.dask.dask_client import dask_client
 
 
-def test_taskgraph_futures_with_dask(random_data, a_watcher, an_update):
+@pytest.fixture()
+def local_dask_client():
     from superduperdb.misc.configs import CONFIG
+
+    client = dask_client(CONFIG.config.dask, local=True)
+    yield client
+    client.shutdown()
+
+
+def test_taskgraph_futures_with_dask(
+    local_dask_client, a_watcher, random_data, an_update
+):
+    from superduperdb.misc.configs import CONFIG
+
     with patch.object(CONFIG.config, "remote", True):
         random_data.remote = True
-        client = dask_client(CONFIG.config.dask)
-        random_data._distributed_client = client
-        output, graph = random_data.execute(Collection(name='documents').insert_many(an_update))
+        random_data._distributed_client = local_dask_client
+        output, graph = random_data.execute(
+            Collection(name='documents').insert_many(an_update)
+        )
 
-    client.wait_all_pending_task()
-    time.sleep(3)
+    next(random_data.execute(Collection(name='documents').find({'update': True})))
+    local_dask_client.wait_all_pending_tasks()
     nodes = graph.G.nodes
     jobs = [nodes[node]['job'] for node in nodes]
     assert all([job.future.status == 'finished' for job in jobs])
 
-def test_insert_with_dask(random_data, a_watcher, an_update):
+
+def test_insert_with_dask(a_watcher, random_data, local_dask_client, an_update):
     from superduperdb.misc.configs import CONFIG
+
     with patch.object(CONFIG.config, "remote", True):
         random_data.remote = True
-        client = dask_client(CONFIG.config.dask)
-        random_data._distributed_client = client
+        random_data._distributed_client = local_dask_client
         random_data.execute(Collection(name='documents').insert_many(an_update))
-        time.sleep(3)
-        r = next(random_data.execute(Collection(name='documents').find({'update': True})))
-        assert 'linear_a' in r['_outputs']['x']
-
+        local_dask_client.wait_all_pending_tasks()
+        r = next(
+            random_data.execute(Collection(name='documents').find({'update': True}))
+        )
+    assert 'linear_a' in r['_outputs']['x']

--- a/tests/material/docker-compose.yml
+++ b/tests/material/docker-compose.yml
@@ -27,6 +27,25 @@ services:
     volumes:
       - ./mongo-init.sh:/scripts/mongo-init.sh
 
+  dask-scheduler:
+    image: superduperdb:latest
+    container_name: sddb-dask-scheduler
+    restart: always
+    command:
+      - dask
+      - scheduler
+
+  dask-worker:
+    image: superduperdb:latest
+    container_name: sddb-dask-worker
+    restart: always
+    depends_on:
+      - dask-scheduler
+    command:
+      - dask
+      - worker
+      - dask-scheduler:8786
+
   vector-search:
     image: superduperdb:latest
     container_name: sddb-vector-search
@@ -56,24 +75,6 @@ services:
       - -m
       - superduperdb.cluster.model_server
 
-  dask-scheduler:
-    image: superduperdb:latest
-    container_name: sddb-dask-scheduler
-    restart: always
-    command:
-      - dask
-      - scheduler
-
-  dask-worker:
-    image: superduperdb:latest
-    container_name: sddb-dask-worker
-    restart: always
-    depends_on:
-      - dask-scheduler
-    command:
-      - dask
-      - worker
-      - dask-scheduler:8786
 
   jupyter:
     image: superduperdb-jupyter:latest

--- a/tests/unittests/core/test_model.py
+++ b/tests/unittests/core/test_model.py
@@ -15,7 +15,7 @@ def test_predict(random_data, float_tensors_32):
 
     X = [r['x'] for r in random_data.execute(Collection(name='documents').find())]
 
-    out = m.predict(X=X, remote=False)
+    out = m.predict(X=X, distributed=False)
 
     assert len(out) == len(X)
 
@@ -23,5 +23,5 @@ def test_predict(random_data, float_tensors_32):
         X='x',
         db=random_data,
         select=Collection(name='documents').find(),
-        remote=False,
+        distributed=False,
     )

--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -137,7 +137,7 @@ def test_validate_component(with_vector_index, si_validation, metric):
 
 
 def test_insert(random_data, a_watcher, an_update):
-    random_data.execute(Collection(name='documents').insert_many(an_update))
+    random_data.execute(Collection(name='documents').insert_many(an_update, flag=True))
     r = next(random_data.execute(Collection(name='documents').find({'update': True})))
     assert 'linear_a' in r['_outputs']['x']
     assert (

--- a/tests/unittests/datalayer/mongodb/test_database.py
+++ b/tests/unittests/datalayer/mongodb/test_database.py
@@ -137,7 +137,7 @@ def test_validate_component(with_vector_index, si_validation, metric):
 
 
 def test_insert(random_data, a_watcher, an_update):
-    random_data.execute(Collection(name='documents').insert_many(an_update, flag=True))
+    random_data.execute(Collection(name='documents').insert_many(an_update))
     r = next(random_data.execute(Collection(name='documents').find({'update': True})))
     assert 'linear_a' in r['_outputs']['x']
     assert (


### PR DESCRIPTION
## Description
We have run_on_dask method for callable and method jobs which means tasks on task graph can be distributed on a distributed cluster like dask in our case.

This pr intends to fix some of the huddles which now makes our task graph possible to submit on a dask cluster.

## Related Issue(s)

#410 
## Checklist

- [x] Change or addition is covered by unit and/or integration tests. If bugfix, there should be at least one test that fails pre-PR and passes after.
- [ ] Classes and functions substantially affected by this PR have `sphinx` format docstrings added or updated.
- [ ] If your changes introduce modifications to functionality, behavior, or usage of the project, please ensure that the documentation is updated accordingly.
<!-- Update relevant sections such as README files and user guides to help users understand the changes and how to use the updated features. -->

## Additional Notes
Current we are submitting single tasks on the dask cluster, we need to find a. way to distribute the task graph itself.
<!-- Add any additional notes, comments, or explanations that may be helpful to the reviewers -->



