### PR TITLE
Remove notebooks from language stats.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+notebooks/* linguist-vendored

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 # Welcome to SuperDuperDB!
 
+
 > An AI-database management system for the full PyTorch model-development lifecycle
 
 Full documentation [here](https://superduperdb.github.io/superduperdb).


### PR DESCRIPTION
## Description

Ignore Jupyter notebooks in GitHub language stats.

(Apparently it takes a number of hours for the stats calculation to be re-triggered. I also read somewhere that someone needed to modify `README.md`. Seemed unlikely, but I added a dummy change as I didn't want to spend time on this.)

## Related Issue(s)

#433 

## Checklist

N/A

## Additional Notes

- https://github.com/github-linguist/linguist/issues/197



