### PR TITLE
Replace t.Optional[t.Any] with t.Any

### DIFF
--- a/superduperdb/core/artifact.py
+++ b/superduperdb/core/artifact.py
@@ -12,10 +12,10 @@ class ArtifactSavingError(Exception):
 class Artifact:
     def __init__(
         self,
-        _artifact: t.Optional[t.Any] = None,
+        _artifact: t.Any = None,
         serializer: str = 'dill',
         info: t.Optional[t.Dict] = None,
-        file_id: t.Optional[t.Any] = None,
+        file_id: t.Any = None,
     ):
         self.serializer = serializer
         self._artifact = _artifact

--- a/superduperdb/core/dataset.py
+++ b/superduperdb/core/dataset.py
@@ -22,7 +22,7 @@ class Dataset(Component):
     creation_date: t.Optional[str] = None
     raw_data: t.Optional[t.Union[Artifact, t.Any]] = None
     version: t.Optional[int] = None
-    db: dc.InitVar[t.Optional[t.Any]] = None
+    db: dc.InitVar[t.Any] = None
 
     def __post_init__(self, db):
         if self.creation_date is None:

--- a/superduperdb/core/job.py
+++ b/superduperdb/core/job.py
@@ -10,7 +10,7 @@ def job(f):
     def wrapper(
         *args,
         distributed=False,
-        db: t.Optional[t.Any] = None,
+        db: t.Any = None,
         dependencies: t.List[Job] = (),  # type: ignore[assignment]
         **kwargs,
     ):
@@ -59,9 +59,7 @@ class Job:
             'stderr': [],
         }
 
-    def __call__(
-        self, db: t.Optional[t.Any] = None, distributed=False, dependencies=()
-    ):
+    def __call__(self, db: t.Any = None, distributed=False, dependencies=()):
         raise NotImplementedError
 
 
@@ -96,9 +94,7 @@ class FunctionJob(Job):
         )
         return
 
-    def __call__(
-        self, db: t.Optional[t.Any] = None, distributed=False, dependencies=()
-    ):
+    def __call__(self, db: t.Any = None, distributed=False, dependencies=()):
         if db is None:
             from superduperdb.datalayer.base.build import build_datalayer
 
@@ -155,9 +151,7 @@ class ComponentJob(Job):
 
         return
 
-    def __call__(
-        self, db: t.Optional[t.Any] = None, distributed=False, dependencies=()
-    ):
+    def __call__(self, db: t.Any = None, distributed=False, dependencies=()):
         if db is None:
             from superduperdb.datalayer.base.build import build_datalayer
 

--- a/superduperdb/core/model.py
+++ b/superduperdb/core/model.py
@@ -70,7 +70,7 @@ class Model(Component):
     training_configuration: t.Union[str, _TrainingConfiguration, None] = None
     version: t.Optional[int] = None
     metric_values: t.Optional[t.Dict] = dc.field(default_factory=dict)
-    db: dc.InitVar[t.Optional[t.Any]] = None
+    db: dc.InitVar[t.Any] = None
     future: t.Optional[Future] = None
 
     def __post_init__(self, db):
@@ -147,7 +147,7 @@ class Model(Component):
     def _fit(
         self,
         X: t.Any,
-        y: t.Optional[t.Any] = None,
+        y: t.Any = None,
         db: t.Optional['BaseDatabase'] = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
         dependencies: t.List[Job] = (),  # type: ignore[assignment]
@@ -161,7 +161,7 @@ class Model(Component):
     def fit(
         self,
         X: t.Any,
-        y: t.Optional[t.Any] = None,
+        y: t.Any = None,
         db: t.Optional['BaseDatabase'] = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
         distributed: bool = False,
@@ -334,7 +334,7 @@ class ModelEnsemble(Component):
     def fit(
         self,
         X: t.Any,
-        y: t.Optional[t.Any] = None,
+        y: t.Any = None,
         db: t.Optional['BaseDatabase'] = None,  # type: ignore[name-defined]
         select: t.Optional[Select] = None,
         distributed: bool = False,

--- a/superduperdb/core/vector_index.py
+++ b/superduperdb/core/vector_index.py
@@ -53,7 +53,7 @@ class VectorIndex(Component):
     indexing_watcher: t.Union[Watcher, str]
     compatible_watchers: t.List[t.Union[Watcher, str]] = dc.field(default_factory=list)
     measure: str = 'cosine'
-    db: dc.InitVar[t.Optional[t.Any]] = None
+    db: dc.InitVar[t.Any] = None
     version: t.Optional[int] = None
     metric_values: t.Optional[t.Dict] = dc.field(default_factory=dict)
 
@@ -113,7 +113,7 @@ class VectorIndex(Component):
     def get_nearest(
         self,
         like: Document,
-        db: t.Optional[t.Any] = None,
+        db: t.Any = None,
         outputs: t.Optional[t.Dict] = None,
         featurize: bool = True,
         ids: t.Optional[t.List[str]] = None,

--- a/superduperdb/core/watcher.py
+++ b/superduperdb/core/watcher.py
@@ -29,7 +29,7 @@ class Watcher(Component):
     active: bool = True
     version: t.Optional[int] = None
     identifier: t.Optional[str] = None
-    db: dc.InitVar[t.Optional[t.Any]] = None
+    db: dc.InitVar[t.Any] = None
 
     def __post_init__(self, db):
         if isinstance(self.model, str) and db is not None:


### PR DESCRIPTION
## Description

`t.Any` and `t.Optional[t.Any]` represent exactly the same types (`t.Any` always includes `None`), so the shorter and more common one should be used

## Related Issue(s)

See #408 
