### PR TITLE
Speed up and despam CLI startup

### DIFF
--- a/superduperdb/cli/serve.py
+++ b/superduperdb/cli/serve.py
@@ -1,5 +1,4 @@
 from . import command
-from superduperdb.serve.server import serve as _serve
 import superduperdb as s
 import time
 import webbrowser
@@ -7,7 +6,9 @@ import webbrowser
 
 @command(help='Start server')
 def serve():
-    _serve()
+    from superduperdb.serve.server import serve
+
+    serve()
 
 
 def _open_page(open_delay):

--- a/superduperdb/vector_search/faiss_index.py
+++ b/superduperdb/vector_search/faiss_index.py
@@ -1,7 +1,5 @@
 import numpy
 import os
-import faiss
-import torch
 
 from superduperdb.vector_search.base import BaseVectorIndex
 
@@ -24,6 +22,8 @@ class FaissVectorIndex(BaseVectorIndex):
     name = 'faiss'
 
     def __init__(self, h, index, measure='l2', faiss_index=None):
+        import faiss
+
         super().__init__(h, index, measure)
         self.h = self.h.astype('float32')
         if faiss_index is None:
@@ -45,6 +45,8 @@ class FaissVectorIndex(BaseVectorIndex):
         self.faiss_index = faiss_index
 
     def find_nearest_from_arrays(self, h, n=100):
+        import torch
+
         if isinstance(h, list):
             h = numpy.array(h).astype('float32')
         if isinstance(h, torch.Tensor):


### PR DESCRIPTION
## Description

Tiny annoyance removed.

Starting up the superduperdb cli with e.g. `python -m superduperdb --help` took three seconds and generated six lines of irrelevant output.

These two tiny changes reduced it to 0.3 seconds and no output.
