### PR TITLE
Make ROOT consistent everwhere

### DIFF
--- a/superduperdb/__init__.py
+++ b/superduperdb/__init__.py
@@ -1,12 +1,11 @@
 from .misc import config, configs
 from .misc.jsonable import JSONable
-from pathlib import Path
 
 __all__ = 'CFG', 'ICON', 'JSONable', 'ROOT', 'config', 'log', 'logging'
 
 CFG = configs.build_config()
 ICON = '🔮'
-ROOT = Path(__file__).parent
+ROOT = configs.ROOT
 
 from .misc import logger  # noqa: E402
 

--- a/superduperdb/misc/configs.py
+++ b/superduperdb/misc/configs.py
@@ -8,17 +8,24 @@ import os
 
 File = t.Union[Path, str]
 
-ROOT = Path(__file__).parents[1]
+# The top-level directory of the project
+ROOT = Path(__file__).parents[2]
+
+# The default prefix used for config environment variables
 PREFIX = 'SUPERDUPERDB_'
+
+# The name of the environment variable used to read the config files.
+# This value needs to be read before all the other config values are.
 FILES_NAME = 'CONFIG_FILES'
 
+# The base name of the configs file
 CONFIG_FILE = 'configs.json'
 
-LOCAL_CONFIG = Path(CONFIG_FILE)
-PROJECT_CONFIG = ROOT / CONFIG_FILE
-USER_CONFIG = Path(f'~/.superduperdb/{CONFIG_FILE}').expanduser()
+_LOCAL_CONFIG = Path(CONFIG_FILE)
+_PROJECT_CONFIG = ROOT / CONFIG_FILE
+_USER_CONFIG = Path(f'~/.superduperdb/{CONFIG_FILE}').expanduser()
 
-ALL_CONFIGS = PROJECT_CONFIG, LOCAL_CONFIG, USER_CONFIG
+_ALL_CONFIGS = _PROJECT_CONFIG, _LOCAL_CONFIG, _USER_CONFIG
 
 FILE_SEP = ','
 
@@ -46,5 +53,5 @@ class ConfigSettings:
 
 
 def build_config():
-    CONFIG = ConfigSettings(config.Config, ALL_CONFIGS, PREFIX)
+    CONFIG = ConfigSettings(config.Config, _ALL_CONFIGS, PREFIX)
     return CONFIG.config


### PR DESCRIPTION
## Description

OOPS, I broke this weeks ago and no one noticed!  

`superduperdb.ROOT` is the top-most directory in the project, probably your `superduperdb-stealth/` directory as of this writing.

It was in two places, and one of them was wrong, causing the wrong config files to be read if you had one.

The error because there are two files that are included before all the other files, but now I define `ROOT` in one of them, and import it, all is good.