### PR TITLE
Add action to release package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+name: Release
+on:
+  workflow_dispatch:  # allows triggering a github action manually - see 'Actions' tab
+    inputs:
+      version:
+        description: Version number to be attached to Python package
+        type: string
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+          shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      
+      - name: Set up Python 3.10
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+ 
+      - name: Install dependencies
+        run: pip install -r requirements/requirements-lint.txt
+
+      - name: Create version dotfile for build
+        run: |
+          touch .SUPERDUPERDB_VERSION
+          echo ${{ github.event.inputs.version }} > .SUPERDUPERDB_VERSION
+
+      - name: Build
+        run: python -m build
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  create-release:
+    needs: ['build']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      
+        # Artifacts located in artifact/
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+
+      - name: create release
+        run: >
+          gh release create --draft --repo ${{ github.repository }}
+          ${{ github.ref_name }}
+          artifact/*
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ packages = ["superduperdb"]
 
 [project]
 name = "superduperdb"
-version = "0.0.4"  # TO BE UPDATED BEFORE RELEASE
 description = "🔮 Super-power your database with AI 🔮"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -24,10 +23,11 @@ classifiers = [  # TO BE EXTENDED BEFORE RELEASE
     "Typing :: Typed"  # TO BE CONFIRMED BEFORE RELEASE
 ]
 requires-python = ">=3.8"
-dynamic = ["dependencies"]
+dynamic = ["dependencies", "version"]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements/requirements.in"] }
+version = {file = ["./.SUPERDUPERDB_VERSION"]}
 
 [project.urls]
 homepage = "https://www.superduperdb.com/"


### PR DESCRIPTION
## Description

This adds an action to automate the new release of SuperDuperDB on GitHub.

This action **does not** upload to PyPI. It only builds and uploads the package to the release section on GitHub.

It works by manually triggering the action and inputing a version number.

## Related Issue(s)

#433 

## Checklist

N/A

## Additional Notes

If we wish to automate the upload to PyPI, we can always add it on to this action in the future.


