### PR TITLE
Install build dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10'
  
       - name: Install dependencies
-        run: pip install -r requirements/requirements-lint.txt
+        run: python -m pip install --upgrade build
 
       - name: Create version dotfile for build
         run: |


### PR DESCRIPTION
## Description

Install missing `build` package from action.

## Related Issue(s)

#433 

## Checklist

N/A

## Additional Notes

N/A


