### PR TITLE
Add Changelog action

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,2 @@
+## Latest Changes
+

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -1,0 +1,24 @@
+name: Latest Changes
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  latest-changes:
+    # if required so that the job is only run when the PR is merged
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.LATEST_CHANGES }} # This is a personal access token with the `repo` scope
+      - uses: docker://tiangolo/latest-changes:0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest_changes_file: .github/release-notes.md
+          latest_changes_header: '## Latest Changes\n\n'
+          debug_logs: true


### PR DESCRIPTION
## Description

This PR adds a new action to automatically add latest changes to a specified file after each PR merge. The action was developed and is used by the FastAPI author.

After merging a PR to the main branch, it will:
- Find a file .`github/release-notes.md`
- Inside of that file, find a "header" with the text: `## Latest Changes\n\n`
- Right after that, it will add a new list item with the title from the PR, the PR number, a link to the PR itself, the PR author and a link to the author as well.

An example and further details can be found [here](https://github.com/tiangolo/latest-changes#how-to-use).

An example from the FastAPI repo of how it all looks is [here](https://github.com/tiangolo/fastapi/blob/master/docs/en/docs/release-notes.md) - the section below `Latest Changes` has been automatically added by the action, and then the `.md` file is formatted more thoroughly before every release.

## Related Issue(s)

#433 

## Checklist

N/A

## Additional Notes

This action will require permission to write to the `main` branch. As such, an admin will need to create a GitHub token (please call it `LATEST_CHANGES`) and give it repo scope permissions.



