### PR TITLE
Fix doc build (fix #474)

### DIFF
--- a/superduperdb/cli/docs.py
+++ b/superduperdb/cli/docs.py
@@ -9,6 +9,7 @@ import shutil
 DOCS = 'docs'
 DOCS_ROOT = ROOT / DOCS
 SOURCE_ROOT = DOCS_ROOT / 'source'
+CODE_ROOT = ROOT / 'superduperdb'
 GH_PAGES = ROOT / '.cache/gh-pages'
 UPSTREAM = 'git@github.com:SuperDuperDB/superduperdb-stealth.git'
 
@@ -39,6 +40,7 @@ def docs(
         git_gh('pull')
 
     _clean()
+    run_gh(('sphinx-apidoc', '-f', '-o', str(SOURCE_ROOT), str(CODE_ROOT)))
     run_gh(('sphinx-build', '-a', str(DOCS_ROOT), '.'))
 
     if commit_message:


### PR DESCRIPTION
## Additional Notes

This change in the docs generates hundreds of warnings complaining about duplicate API symbols, which is why I turned it off, but it turns out that having done it once at some point is necessary.

There is much here I still do not understand...