### PR TITLE
Metadata optional getter

### DIFF
--- a/superduperdb/datalayer/base/datalayer.py
+++ b/superduperdb/datalayer/base/datalayer.py
@@ -697,24 +697,13 @@ class Datalayer:
             return
 
         if n_download_workers is None:
-            try:
-                n_download_workers = self.metadata.get_metadata(
-                    key='n_download_workers'
-                )
-            except TypeError:
-                n_download_workers = 0
+            n_download_workers = self.metadata.get_metadata('n_download_workers', 0)
 
         if headers is None:
-            try:
-                headers = self.metadata.get_metadata(key='headers')
-            except TypeError:
-                headers = 0
+            headers = self.metadata.get_metadata('headers', 0)
 
         if timeout is None:
-            try:
-                timeout = self.metadata.get_metadata(key='download_timeout')
-            except TypeError:
-                timeout = None
+            timeout = self.metadata.get_metadata('download_timeout')
 
         def download_update(key, id, bytes):
             return query.download_update(db=self, key=key, id=id, bytes=bytes)

--- a/superduperdb/datalayer/base/download_content.py
+++ b/superduperdb/datalayer/base/download_content.py
@@ -55,13 +55,13 @@ def download_content(
         return None
 
     if n_download_workers is None:
-        n_download_workers = db.metadata.get_metadata_optional(key='n_download_workers', default=0)
+        n_download_workers = db.metadata.get_metadata_optional('n_download_workers', 0)
 
     if headers is None:
-        headers = db.metadata.get_metadata_optional(key='headers')
+        headers = db.metadata.get_metadata_optional('headers')
 
     if timeout is None:
-        timeout = db.metadata.get_metadata_optional(key='download_timeout')
+        timeout = db.metadata.get_metadata_optional('download_timeout')
 
     def _download_update(key, id, bytes):
         return query.download_update(db=db, key=key, id=id, bytes=bytes)

--- a/superduperdb/datalayer/base/download_content.py
+++ b/superduperdb/datalayer/base/download_content.py
@@ -55,22 +55,13 @@ def download_content(
         return None
 
     if n_download_workers is None:
-        try:
-            n_download_workers = db.metadata.get_metadata(key='n_download_workers')
-        except TypeError:
-            n_download_workers = 0
+        n_download_workers = db.metadata.get_metadata_optional(key='n_download_workers', default=0)
 
     if headers is None:
-        try:
-            headers = db.metadata.get_metadata(key='headers')
-        except TypeError:
-            pass
+        headers = db.metadata.get_metadata_optional(key='headers')
 
     if timeout is None:
-        try:
-            timeout = db.metadata.get_metadata(key='download_timeout')
-        except TypeError:
-            pass
+        timeout = db.metadata.get_metadata_optional(key='download_timeout')
 
     def _download_update(key, id, bytes):
         return query.download_update(db=db, key=key, id=id, bytes=bytes)

--- a/superduperdb/datalayer/base/metadata.py
+++ b/superduperdb/datalayer/base/metadata.py
@@ -94,6 +94,12 @@ class MetaDataStore(ABC):
     def get_metadata(self, key):
         pass
 
+    def get_metadata_optional(self, key, default=None):
+        try:
+            return self.get_metadata(key)
+        except KeyError:
+            return default
+
     @abstractmethod
     def get_latest_version(
         self, variety: str, identifier: str, allow_hidden: bool = False

--- a/superduperdb/datalayer/base/metadata.py
+++ b/superduperdb/datalayer/base/metadata.py
@@ -91,14 +91,8 @@ class MetaDataStore(ABC):
         pass
 
     @abstractmethod
-    def get_metadata(self, key):
+    def get_metadata(self, key, default=None):
         pass
-
-    def get_metadata_optional(self, key, default=None):
-        try:
-            return self.get_metadata(key)
-        except KeyError:
-            return default
 
     @abstractmethod
     def get_latest_version(

--- a/superduperdb/datalayer/mongodb/metadata.py
+++ b/superduperdb/datalayer/mongodb/metadata.py
@@ -43,9 +43,12 @@ class MongoMetaDataStore(MetaDataStore):
     def get_job(self, identifier: str):
         return self.job_collection.find_one({'identifier': identifier})
 
-    def get_metadata(self, key):
+    def get_metadata(self, key, default=None):
         meta = self.meta_collection.find_one({'key': key}) or {}
-        return meta['value']
+        try:
+            return meta['value']
+        except KeyError:
+            return default
 
     def get_latest_version(
         self, variety: str, identifier: str, allow_hidden: bool = False

--- a/superduperdb/datalayer/mongodb/metadata.py
+++ b/superduperdb/datalayer/mongodb/metadata.py
@@ -44,7 +44,8 @@ class MongoMetaDataStore(MetaDataStore):
         return self.job_collection.find_one({'identifier': identifier})
 
     def get_metadata(self, key):
-        return self.meta_collection.find_one({'key': key})['value']
+        meta = self.meta_collection.find_one({'key': key}) or {}
+        return meta['value']
 
     def get_latest_version(
         self, variety: str, identifier: str, allow_hidden: bool = False


### PR DESCRIPTION
## Description

This patch adds a new method `get_metadata_optional` to the base `Metadata` class, to preserve semantic of the Python dictionary `get(key, default=None)` method: when key is not found a `KeyError` is raised, handled and `default` value is returned.

## Related Issue(s)

<!-- If your pull request is related to any GitHub issue(s), mention them here with the appropriate links -->

## Checklist

<!-- Mark the tasks that are completed. You can add or remove items as necessary -->

- [ ] Change or addition is covered by unit and/or integration tests. If bugfix, there should be at least one test that fails pre-PR and passes after.
- [ ] Classes and functions substantially affected by this PR have `sphinx` format docstrings added or updated.
- [ ] If your changes introduce modifications to functionality, behavior, or usage of the project, please ensure that the documentation is updated accordingly.
<!-- Update relevant sections such as README files and user guides to help users understand the changes and how to use the updated features. -->



