### PR TITLE
Remove remnants of langchain and update to pydantic 2

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,30 +8,20 @@ accelerate==0.21.0
     # via -r requirements.in
 aiohttp==3.8.4
     # via
-    #   fsspec
     #   lancedb
-    #   langchain
     #   openai
 aiosignal==1.3.1
-    # via
-    #   aiohttp
-    #   ray
+    # via aiohttp
 alabaster==0.7.13
     # via sphinx
 anyio==3.7.1
-    # via
-    #   httpcore
-    #   starlette
+    # via httpcore
 appnope==0.1.3
     # via ipython
-arrow==1.2.3
-    # via lightning
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   langchain
+    # via aiohttp
 attr==0.3.2
     # via lancedb
 attrs==23.1.0
@@ -39,25 +29,19 @@ attrs==23.1.0
     #   aiohttp
     #   interrogate
     #   jsonschema
-    #   ray
     #   referencing
 babel==2.12.1
     # via sphinx
 backcall==0.2.0
     # via ipython
-backoff==2.2.1
-    # via lightning
 beautifulsoup4==4.12.2
     # via
     #   furo
-    #   lightning
     #   nbconvert
 black==23.7.0
     # via -r requirements-lint.in
 bleach==6.0.0
     # via nbconvert
-blessed==1.20.0
-    # via inquirer
 blinker==1.6.2
     # via flask
 boto3==1.28.5
@@ -88,12 +72,8 @@ click==8.1.6
     #   distributed
     #   flask
     #   interrogate
-    #   lightning
-    #   lightning-cloud
     #   pip-tools
-    #   ray
     #   typer
-    #   uvicorn
 cloudpickle==2.2.1
     # via
     #   dask
@@ -102,22 +82,14 @@ colorama==0.4.6
     # via interrogate
 coverage[toml]==7.2.7
     # via pytest-cov
-croniter==1.4.1
-    # via lightning
 dask[distributed]==2023.5.0
     # via
     #   -r requirements.in
     #   distributed
-dataclasses-json==0.5.12
-    # via langchain
-dateutils==0.6.12
-    # via lightning
 decorator==5.1.1
     # via
     #   ipython
     #   retry
-deepdiff==6.3.1
-    # via lightning
 defusedxml==0.7.1
     # via nbconvert
 dek==1.2.0
@@ -135,8 +107,6 @@ docutils==0.18.1
     #   myst-parser
     #   nbsphinx
     #   sphinx
-environs==9.5.0
-    # via pymilvus
 exceptiongroup==1.1.2
     # via
     #   anyio
@@ -145,11 +115,6 @@ executing==1.2.0
     # via stack-data
 faiss-cpu==1.7.4
     # via -r requirements.in
-fastapi==0.100.0
-    # via
-    #   -r requirements.in
-    #   lightning
-    #   lightning-cloud
 fastjsonschema==2.17.1
     # via nbformat
 fil==1.3.0
@@ -157,7 +122,6 @@ fil==1.3.0
 filelock==3.12.2
     # via
     #   huggingface-hub
-    #   ray
     #   torch
     #   transformers
 flask==2.3.2
@@ -173,23 +137,14 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-    #   ray
-fsspec[http]==2023.6.0
+fsspec==2023.6.0
     # via
     #   dask
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
 furo==2023.5.20
     # via -r requirements-docs.in
-grpcio==1.49.1
-    # via
-    #   pymilvus
-    #   ray
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
+    # via httpcore
 httpcore==0.17.3
     # via
     #   dnspython
@@ -221,8 +176,6 @@ importlib-resources==6.0.0
     #   jsonschema-specifications
 iniconfig==2.0.0
     # via pytest
-inquirer==3.1.3
-    # via lightning
 interrogate==1.5.0
     # via -r requirements-lint.in
 ipython==8.12.2
@@ -230,16 +183,13 @@ ipython==8.12.2
 isort==5.12.0
     # via -r requirements-lint.in
 itsdangerous==2.1.2
-    # via
-    #   flask
-    #   starsessions
+    # via flask
 jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via
     #   distributed
     #   flask
-    #   lightning
     #   myst-parser
     #   nbconvert
     #   nbsphinx
@@ -252,9 +202,7 @@ jmespath==1.0.1
 joblib==1.3.1
     # via scikit-learn
 jsonschema==4.18.4
-    # via
-    #   nbformat
-    #   ray
+    # via nbformat
 jsonschema-specifications==2023.7.1
     # via jsonschema
 jupyter-client==8.3.0
@@ -269,21 +217,8 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 lancedb==0.1.10
     # via -r requirements.in
-langchain==0.0.235
-    # via -r requirements.in
-langsmith==0.0.7
-    # via langchain
 libcst==1.0.1
     # via monkeytype
-lightning==2.0.5
-    # via -r requirements.in
-lightning-cloud==0.5.37
-    # via lightning
-lightning-utilities==0.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 locket==1.0.0
     # via
     #   distributed
@@ -294,16 +229,11 @@ markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-    #   rich
 markupsafe==2.1.3
     # via
     #   jinja2
     #   nbconvert
     #   werkzeug
-marshmallow==3.19.0
-    # via
-    #   dataclasses-json
-    #   environs
 matplotlib-inline==0.1.6
     # via ipython
 mdit-py-plugins==0.4.0
@@ -317,9 +247,7 @@ monkeytype==23.3.0
 mpmath==1.3.0
     # via sympy
 msgpack==1.0.5
-    # via
-    #   distributed
-    #   ray
+    # via distributed
 multidict==6.0.4
     # via
     #   aiohttp
@@ -349,31 +277,18 @@ networkx==3.1
     # via
     #   -r requirements.in
     #   torch
-numexpr==2.8.4
-    # via langchain
 numpy==1.24.4
     # via
     #   -r requirements.in
     #   accelerate
-    #   langchain
-    #   lightning
-    #   numexpr
     #   pandas
     #   pyarrow
     #   pylance
-    #   pymilvus
-    #   pytorch-lightning
-    #   ray
     #   scikit-learn
     #   scipy
-    #   torchmetrics
     #   transformers
 openai==0.27.8
     # via -r requirements.in
-openapi-schema-pydantic==1.2.4
-    # via langchain
-ordered-set==4.1.0
-    # via deepdiff
 overrides==7.3.1
     # via -r requirements.in
 packaging==23.1
@@ -384,21 +299,14 @@ packaging==23.1
     #   dask
     #   distributed
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
-    #   marshmallow
     #   nbconvert
     #   pytest
-    #   pytorch-lightning
-    #   ray
     #   sphinx
-    #   torchmetrics
     #   transformers
 pandas==2.0.3
     # via
     #   -r requirements.in
     #   pylance
-    #   pymilvus
 pandoc==2.3
     # via -r requirements-docs.in
 pandocfilters==1.5.0
@@ -431,15 +339,10 @@ ply==3.11
     # via pandoc
 prompt-toolkit==3.0.39
     # via ipython
-protobuf==4.23.4
-    # via
-    #   pymilvus
-    #   ray
 psutil==5.9.5
     # via
     #   accelerate
     #   distributed
-    #   lightning
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -451,26 +354,15 @@ py==1.11.0
 pyarrow==12.0.1
     # via pylance
 pydantic==1.10.11
-    # via
-    #   fastapi
-    #   lancedb
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   openapi-schema-pydantic
+    # via lancedb
 pygments==2.15.1
     # via
     #   furo
     #   ipython
     #   nbconvert
-    #   rich
     #   sphinx
-pyjwt==2.8.0
-    # via lightning-cloud
 pylance==0.5.8
     # via lancedb
-pymilvus==2.2.13
-    # via -r requirements.in
 pymongo==4.4.1
     # via -r requirements.in
 pyproject-hooks==1.0.0
@@ -483,26 +375,12 @@ pytest-cov==4.1.0
     # via -r requirements-test.in
 python-dateutil==2.8.2
     # via
-    #   arrow
     #   botocore
-    #   croniter
-    #   dateutils
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.0
-    # via environs
-python-editor==1.0.4
-    # via inquirer
-python-multipart==0.0.6
-    # via
-    #   lightning
-    #   lightning-cloud
-pytorch-lightning==2.0.5
-    # via lightning
 pytz==2023.3
     # via
     #   babel
-    #   dateutils
     #   pandas
 pyyaml==6.0.1
     # via
@@ -510,21 +388,13 @@ pyyaml==6.0.1
     #   dask
     #   distributed
     #   huggingface-hub
-    #   langchain
     #   libcst
-    #   lightning
     #   myst-parser
-    #   pytorch-lightning
-    #   ray
     #   transformers
 pyzmq==25.1.0
     # via jupyter-client
 ratelimiter==1.2.0.post0
     # via lancedb
-ray==2.5.1
-    # via -r requirements.in
-readchar==4.0.5
-    # via inquirer
 readerwriterlock==1.0.9
     # via -r requirements.in
 referencing==0.30.0
@@ -536,22 +406,12 @@ regex==2023.6.3
 requests==2.31.0
     # via
     #   -r requirements.in
-    #   fsspec
     #   huggingface-hub
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   lightning-cloud
     #   openai
-    #   ray
     #   sphinx
     #   transformers
 retry==0.9.2
     # via lancedb
-rich==13.4.2
-    # via
-    #   lightning
-    #   lightning-cloud
 rpds-py==0.9.2
     # via
     #   jsonschema
@@ -572,9 +432,6 @@ six==1.16.0
     # via
     #   asttokens
     #   bleach
-    #   blessed
-    #   grpcio
-    #   lightning-cloud
     #   python-dateutil
 sniffio==1.3.0
     # via
@@ -617,17 +474,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.19
-    # via langchain
 stack-data==0.6.2
     # via ipython
-starlette==0.27.0
-    # via
-    #   fastapi
-    #   lightning
-    #   starsessions
-starsessions==1.3.0
-    # via lightning
 sympy==1.12
     # via torch
 tabulate==0.9.0
@@ -637,9 +485,7 @@ tblib==2.0.0
 tdir==1.6.0
     # via -r requirements-test.in
 tenacity==8.2.2
-    # via
-    #   -r requirements-test.in
-    #   langchain
+    # via -r requirements-test.in
 threadpoolctl==3.2.0
     # via scikit-learn
 tinycss2==1.2.1
@@ -666,13 +512,6 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
-torchmetrics==1.0.1
-    # via
-    #   lightning
-    #   pytorch-lightning
 tornado==6.3.2
     # via
     #   distributed
@@ -682,16 +521,13 @@ tqdm==4.65.0
     #   -r requirements.in
     #   huggingface-hub
     #   lancedb
-    #   lightning
     #   openai
-    #   pytorch-lightning
     #   transformers
 traitlets==5.9.0
     # via
     #   ipython
     #   jupyter-client
     #   jupyter-core
-    #   lightning
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
@@ -720,57 +556,30 @@ typing-extensions==4.7.1
     #   black
     #   boto3-stubs
     #   botocore-stubs
-    #   fastapi
     #   huggingface-hub
     #   ipython
     #   libcst
-    #   lightning
-    #   lightning-utilities
     #   mypy
     #   pydantic
-    #   pytorch-lightning
     #   readerwriterlock
-    #   rich
-    #   sqlalchemy
-    #   starlette
     #   torch
-    #   torchmetrics
     #   typer
     #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
-    # via
-    #   dataclasses-json
-    #   libcst
+    # via libcst
 tzdata==2023.3
     # via pandas
-ujson==5.8.0
-    # via pymilvus
 urllib3==1.26.16
     # via
     #   botocore
     #   distributed
-    #   lightning
-    #   lightning-cloud
     #   requests
-uvicorn==0.23.1
-    # via
-    #   lightning
-    #   lightning-cloud
 wcwidth==0.2.6
-    # via
-    #   blessed
-    #   prompt-toolkit
+    # via prompt-toolkit
 webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.6.1
-    # via
-    #   lightning
-    #   lightning-cloud
-websockets==11.0.3
-    # via lightning
 werkzeug==2.3.6
     # via
     #   -r requirements.in

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -8,38 +8,18 @@ accelerate==0.21.0
     # via -r requirements.in
 aiohttp==3.8.4
     # via
-    #   fsspec
     #   lancedb
-    #   langchain
     #   openai
 aiosignal==1.3.1
-    # via
-    #   aiohttp
-    #   ray
+    # via aiohttp
 anyio==3.7.1
-    # via
-    #   httpcore
-    #   starlette
-arrow==1.2.3
-    # via lightning
+    # via httpcore
 async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   langchain
+    # via aiohttp
 attr==0.3.2
     # via lancedb
 attrs==23.1.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   ray
-    #   referencing
-backoff==2.2.1
-    # via lightning
-beautifulsoup4==4.12.2
-    # via lightning
-blessed==1.20.0
-    # via inquirer
+    # via aiohttp
 blinker==1.6.2
     # via flask
 boto3==1.28.5
@@ -62,31 +42,19 @@ click==8.1.6
     #   dask
     #   distributed
     #   flask
-    #   lightning
-    #   lightning-cloud
-    #   ray
     #   typer
-    #   uvicorn
 cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
 coverage[toml]==7.2.7
     # via pytest-cov
-croniter==1.4.1
-    # via lightning
 dask[distributed]==2023.5.0
     # via
     #   -r requirements.in
     #   distributed
-dataclasses-json==0.5.12
-    # via langchain
-dateutils==0.6.12
-    # via lightning
 decorator==5.1.1
     # via retry
-deepdiff==6.3.1
-    # via lightning
 dek==1.2.0
     # via
     #   tdir
@@ -97,25 +65,17 @@ distributed==2023.5.0
     # via dask
 dnspython==2.4.0
     # via pymongo
-environs==9.5.0
-    # via pymilvus
 exceptiongroup==1.1.2
     # via
     #   anyio
     #   pytest
 faiss-cpu==1.7.4
     # via -r requirements.in
-fastapi==0.100.0
-    # via
-    #   -r requirements.in
-    #   lightning
-    #   lightning-cloud
 fil==1.3.0
     # via -r requirements.in
 filelock==3.12.2
     # via
     #   huggingface-hub
-    #   ray
     #   torch
     #   transformers
 flask==2.3.2
@@ -131,21 +91,12 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-    #   ray
-fsspec[http]==2023.6.0
+fsspec==2023.6.0
     # via
     #   dask
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
-grpcio==1.49.1
-    # via
-    #   pymilvus
-    #   ray
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
+    # via httpcore
 httpcore==0.17.3
     # via
     #   dnspython
@@ -166,23 +117,14 @@ importlib-metadata==6.8.0
     # via
     #   dask
     #   flask
-importlib-resources==6.0.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 iniconfig==2.0.0
     # via pytest
-inquirer==3.1.3
-    # via lightning
 itsdangerous==2.1.2
-    # via
-    #   flask
-    #   starsessions
+    # via flask
 jinja2==3.1.2
     # via
     #   distributed
     #   flask
-    #   lightning
     #   torch
 jmespath==1.0.1
     # via
@@ -190,84 +132,42 @@ jmespath==1.0.1
     #   botocore
 joblib==1.3.1
     # via scikit-learn
-jsonschema==4.18.4
-    # via ray
-jsonschema-specifications==2023.7.1
-    # via jsonschema
 lancedb==0.1.10
     # via -r requirements.in
-langchain==0.0.235
-    # via -r requirements.in
-langsmith==0.0.7
-    # via langchain
-lightning==2.0.5
-    # via -r requirements.in
-lightning-cloud==0.5.37
-    # via lightning
-lightning-utilities==0.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 locket==1.0.0
     # via
     #   distributed
     #   partd
 lorem==0.1.1
     # via -r requirements-test.in
-markdown-it-py==3.0.0
-    # via rich
 markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
-marshmallow==3.19.0
-    # via
-    #   dataclasses-json
-    #   environs
-mdurl==0.1.2
-    # via markdown-it-py
 mpmath==1.3.0
     # via sympy
 msgpack==1.0.5
-    # via
-    #   distributed
-    #   ray
+    # via distributed
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==1.0.0
-    # via typing-inspect
 networkx==3.1
     # via
     #   -r requirements.in
     #   torch
-numexpr==2.8.4
-    # via langchain
 numpy==1.24.4
     # via
     #   -r requirements.in
     #   accelerate
-    #   langchain
-    #   lightning
-    #   numexpr
     #   pandas
     #   pyarrow
     #   pylance
-    #   pymilvus
-    #   pytorch-lightning
-    #   ray
     #   scikit-learn
     #   scipy
-    #   torchmetrics
     #   transformers
 openai==0.27.8
     # via -r requirements.in
-openapi-schema-pydantic==1.2.4
-    # via langchain
-ordered-set==4.1.0
-    # via deepdiff
 overrides==7.3.1
     # via -r requirements.in
 packaging==23.1
@@ -276,56 +176,30 @@ packaging==23.1
     #   dask
     #   distributed
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
-    #   marshmallow
     #   pytest
-    #   pytorch-lightning
-    #   ray
-    #   torchmetrics
     #   transformers
 pandas==2.0.3
     # via
     #   -r requirements.in
     #   pylance
-    #   pymilvus
 partd==1.4.0
     # via dask
 pillow==10.0.0
     # via -r requirements.in
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
 pluggy==1.2.0
     # via pytest
-protobuf==4.23.4
-    # via
-    #   pymilvus
-    #   ray
 psutil==5.9.5
     # via
     #   accelerate
     #   distributed
-    #   lightning
 py==1.11.0
     # via retry
 pyarrow==12.0.1
     # via pylance
 pydantic==1.10.11
-    # via
-    #   fastapi
-    #   lancedb
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   openapi-schema-pydantic
-pygments==2.15.1
-    # via rich
-pyjwt==2.8.0
-    # via lightning-cloud
+    # via lancedb
 pylance==0.5.8
     # via lancedb
-pymilvus==2.2.13
-    # via -r requirements.in
 pymongo==4.4.1
     # via -r requirements.in
 pytest==7.4.0
@@ -336,72 +210,31 @@ pytest-cov==4.1.0
     # via -r requirements-test.in
 python-dateutil==2.8.2
     # via
-    #   arrow
     #   botocore
-    #   croniter
-    #   dateutils
     #   pandas
-python-dotenv==1.0.0
-    # via environs
-python-editor==1.0.4
-    # via inquirer
-python-multipart==0.0.6
-    # via
-    #   lightning
-    #   lightning-cloud
-pytorch-lightning==2.0.5
-    # via lightning
 pytz==2023.3
-    # via
-    #   dateutils
-    #   pandas
+    # via pandas
 pyyaml==6.0.1
     # via
     #   accelerate
     #   dask
     #   distributed
     #   huggingface-hub
-    #   langchain
-    #   lightning
-    #   pytorch-lightning
-    #   ray
     #   transformers
 ratelimiter==1.2.0.post0
     # via lancedb
-ray==2.5.1
-    # via -r requirements.in
-readchar==4.0.5
-    # via inquirer
 readerwriterlock==1.0.9
     # via -r requirements.in
-referencing==0.30.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2023.6.3
     # via transformers
 requests==2.31.0
     # via
     #   -r requirements.in
-    #   fsspec
     #   huggingface-hub
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   lightning-cloud
     #   openai
-    #   ray
     #   transformers
 retry==0.9.2
     # via lancedb
-rich==13.4.2
-    # via
-    #   lightning
-    #   lightning-cloud
-rpds-py==0.9.2
-    # via
-    #   jsonschema
-    #   referencing
 s3transfer==0.6.1
     # via boto3
 safer==4.8.0
@@ -413,11 +246,7 @@ scikit-learn==1.3.0
 scipy==1.10.1
     # via scikit-learn
 six==1.16.0
-    # via
-    #   blessed
-    #   grpcio
-    #   lightning-cloud
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
@@ -426,17 +255,6 @@ sniffio==1.3.0
     #   httpx
 sortedcontainers==2.4.0
     # via distributed
-soupsieve==2.4.1
-    # via beautifulsoup4
-sqlalchemy==2.0.19
-    # via langchain
-starlette==0.27.0
-    # via
-    #   fastapi
-    #   lightning
-    #   starsessions
-starsessions==1.3.0
-    # via lightning
 sympy==1.12
     # via torch
 tblib==2.0.0
@@ -444,9 +262,7 @@ tblib==2.0.0
 tdir==1.6.0
     # via -r requirements-test.in
 tenacity==8.2.2
-    # via
-    #   -r requirements-test.in
-    #   langchain
+    # via -r requirements-test.in
 threadpoolctl==3.2.0
     # via scikit-learn
 tokenizers==0.13.3
@@ -464,13 +280,6 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
-torchmetrics==1.0.1
-    # via
-    #   lightning
-    #   pytorch-lightning
 tornado==6.3.2
     # via distributed
 tqdm==4.65.0
@@ -478,58 +287,26 @@ tqdm==4.65.0
     #   -r requirements.in
     #   huggingface-hub
     #   lancedb
-    #   lightning
     #   openai
-    #   pytorch-lightning
     #   transformers
-traitlets==5.9.0
-    # via lightning
 transformers==4.31.0
     # via -r requirements.in
 typer==0.9.0
     # via -r requirements.in
 typing-extensions==4.7.1
     # via
-    #   fastapi
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   pydantic
-    #   pytorch-lightning
     #   readerwriterlock
-    #   rich
-    #   sqlalchemy
-    #   starlette
     #   torch
-    #   torchmetrics
     #   typer
-    #   typing-inspect
-    #   uvicorn
-typing-inspect==0.9.0
-    # via dataclasses-json
 tzdata==2023.3
     # via pandas
-ujson==5.8.0
-    # via pymilvus
 urllib3==1.26.16
     # via
     #   botocore
     #   distributed
-    #   lightning
-    #   lightning-cloud
     #   requests
-uvicorn==0.23.1
-    # via
-    #   lightning
-    #   lightning-cloud
-wcwidth==0.2.6
-    # via blessed
-websocket-client==1.6.1
-    # via
-    #   lightning
-    #   lightning-cloud
-websockets==11.0.3
-    # via lightning
 werkzeug==2.3.6
     # via
     #   -r requirements.in
@@ -543,9 +320,4 @@ yarl==1.9.2
 zict==3.0.0
     # via distributed
 zipp==3.16.2
-    # via
-    #   importlib-metadata
-    #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+    # via importlib-metadata

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,38 +8,18 @@ accelerate==0.21.0
     # via -r requirements.in
 aiohttp==3.8.4
     # via
-    #   fsspec
     #   lancedb
-    #   langchain
     #   openai
 aiosignal==1.3.1
-    # via
-    #   aiohttp
-    #   ray
+    # via aiohttp
 anyio==3.7.1
-    # via
-    #   httpcore
-    #   starlette
-arrow==1.2.3
-    # via lightning
+    # via httpcore
 async-timeout==4.0.2
-    # via
-    #   aiohttp
-    #   langchain
+    # via aiohttp
 attr==0.3.2
     # via lancedb
 attrs==23.1.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   ray
-    #   referencing
-backoff==2.2.1
-    # via lightning
-beautifulsoup4==4.12.2
-    # via lightning
-blessed==1.20.0
-    # via inquirer
+    # via aiohttp
 blinker==1.6.2
     # via flask
 boto3==1.28.5
@@ -61,52 +41,32 @@ click==8.1.6
     #   dask
     #   distributed
     #   flask
-    #   lightning
-    #   lightning-cloud
-    #   ray
     #   typer
-    #   uvicorn
 cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
-croniter==1.4.1
-    # via lightning
 dask[distributed]==2023.5.0
     # via
     #   -r requirements.in
     #   distributed
-dataclasses-json==0.5.12
-    # via langchain
-dateutils==0.6.12
-    # via lightning
 decorator==5.1.1
     # via retry
-deepdiff==6.3.1
-    # via lightning
 dill==0.3.6
     # via -r requirements.in
 distributed==2023.5.0
     # via dask
 dnspython==2.4.0
     # via pymongo
-environs==9.5.0
-    # via pymilvus
 exceptiongroup==1.1.2
     # via anyio
 faiss-cpu==1.7.4
     # via -r requirements.in
-fastapi==0.100.0
-    # via
-    #   -r requirements.in
-    #   lightning
-    #   lightning-cloud
 fil==1.3.0
     # via -r requirements.in
 filelock==3.12.2
     # via
     #   huggingface-hub
-    #   ray
     #   torch
     #   transformers
 flask==2.3.2
@@ -122,21 +82,12 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-    #   ray
-fsspec[http]==2023.6.0
+fsspec==2023.6.0
     # via
     #   dask
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
-grpcio==1.49.1
-    # via
-    #   pymilvus
-    #   ray
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
+    # via httpcore
 httpcore==0.17.3
     # via dnspython
 huggingface-hub==0.16.4
@@ -150,21 +101,12 @@ importlib-metadata==6.8.0
     # via
     #   dask
     #   flask
-importlib-resources==6.0.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
-inquirer==3.1.3
-    # via lightning
 itsdangerous==2.1.2
-    # via
-    #   flask
-    #   starsessions
+    # via flask
 jinja2==3.1.2
     # via
     #   distributed
     #   flask
-    #   lightning
     #   torch
 jmespath==1.0.1
     # via
@@ -172,82 +114,40 @@ jmespath==1.0.1
     #   botocore
 joblib==1.3.1
     # via scikit-learn
-jsonschema==4.18.4
-    # via ray
-jsonschema-specifications==2023.7.1
-    # via jsonschema
 lancedb==0.1.10
     # via -r requirements.in
-langchain==0.0.235
-    # via -r requirements.in
-langsmith==0.0.7
-    # via langchain
-lightning==2.0.5
-    # via -r requirements.in
-lightning-cloud==0.5.37
-    # via lightning
-lightning-utilities==0.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 locket==1.0.0
     # via
     #   distributed
     #   partd
-markdown-it-py==3.0.0
-    # via rich
 markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
-marshmallow==3.19.0
-    # via
-    #   dataclasses-json
-    #   environs
-mdurl==0.1.2
-    # via markdown-it-py
 mpmath==1.3.0
     # via sympy
 msgpack==1.0.5
-    # via
-    #   distributed
-    #   ray
+    # via distributed
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==1.0.0
-    # via typing-inspect
 networkx==3.1
     # via
     #   -r requirements.in
     #   torch
-numexpr==2.8.4
-    # via langchain
 numpy==1.24.4
     # via
     #   -r requirements.in
     #   accelerate
-    #   langchain
-    #   lightning
-    #   numexpr
     #   pandas
     #   pyarrow
     #   pylance
-    #   pymilvus
-    #   pytorch-lightning
-    #   ray
     #   scikit-learn
     #   scipy
-    #   torchmetrics
     #   transformers
 openai==0.27.8
     # via -r requirements.in
-openapi-schema-pydantic==1.2.4
-    # via langchain
-ordered-set==4.1.0
-    # via deepdiff
 overrides==7.3.1
     # via -r requirements.in
 packaging==23.1
@@ -256,123 +156,56 @@ packaging==23.1
     #   dask
     #   distributed
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
-    #   marshmallow
-    #   pytorch-lightning
-    #   ray
-    #   torchmetrics
     #   transformers
 pandas==2.0.3
     # via
     #   -r requirements.in
     #   pylance
-    #   pymilvus
 partd==1.4.0
     # via dask
 pillow==10.0.0
     # via -r requirements.in
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
-protobuf==4.23.4
-    # via
-    #   pymilvus
-    #   ray
 psutil==5.9.5
     # via
     #   accelerate
     #   distributed
-    #   lightning
 py==1.11.0
     # via retry
 pyarrow==12.0.1
     # via pylance
 pydantic==1.10.11
-    # via
-    #   fastapi
-    #   lancedb
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   openapi-schema-pydantic
-pygments==2.15.1
-    # via rich
-pyjwt==2.8.0
-    # via lightning-cloud
+    # via lancedb
 pylance==0.5.8
     # via lancedb
-pymilvus==2.2.13
-    # via -r requirements.in
 pymongo==4.4.1
     # via -r requirements.in
 python-dateutil==2.8.2
     # via
-    #   arrow
     #   botocore
-    #   croniter
-    #   dateutils
     #   pandas
-python-dotenv==1.0.0
-    # via environs
-python-editor==1.0.4
-    # via inquirer
-python-multipart==0.0.6
-    # via
-    #   lightning
-    #   lightning-cloud
-pytorch-lightning==2.0.5
-    # via lightning
 pytz==2023.3
-    # via
-    #   dateutils
-    #   pandas
+    # via pandas
 pyyaml==6.0.1
     # via
     #   accelerate
     #   dask
     #   distributed
     #   huggingface-hub
-    #   langchain
-    #   lightning
-    #   pytorch-lightning
-    #   ray
     #   transformers
 ratelimiter==1.2.0.post0
     # via lancedb
-ray==2.5.1
-    # via -r requirements.in
-readchar==4.0.5
-    # via inquirer
 readerwriterlock==1.0.9
     # via -r requirements.in
-referencing==0.30.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2023.6.3
     # via transformers
 requests==2.31.0
     # via
     #   -r requirements.in
-    #   fsspec
     #   huggingface-hub
-    #   langchain
-    #   langsmith
-    #   lightning
-    #   lightning-cloud
     #   openai
-    #   ray
     #   transformers
 retry==0.9.2
     # via lancedb
-rich==13.4.2
-    # via
-    #   lightning
-    #   lightning-cloud
-rpds-py==0.9.2
-    # via
-    #   jsonschema
-    #   referencing
 s3transfer==0.6.1
     # via boto3
 safer==4.8.0
@@ -384,11 +217,7 @@ scikit-learn==1.3.0
 scipy==1.10.1
     # via scikit-learn
 six==1.16.0
-    # via
-    #   blessed
-    #   grpcio
-    #   lightning-cloud
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
@@ -396,23 +225,10 @@ sniffio==1.3.0
     #   httpcore
 sortedcontainers==2.4.0
     # via distributed
-soupsieve==2.4.1
-    # via beautifulsoup4
-sqlalchemy==2.0.19
-    # via langchain
-starlette==0.27.0
-    # via
-    #   fastapi
-    #   lightning
-    #   starsessions
-starsessions==1.3.0
-    # via lightning
 sympy==1.12
     # via torch
 tblib==2.0.0
     # via distributed
-tenacity==8.2.2
-    # via langchain
 threadpoolctl==3.2.0
     # via scikit-learn
 tokenizers==0.13.3
@@ -426,13 +242,6 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
-torchmetrics==1.0.1
-    # via
-    #   lightning
-    #   pytorch-lightning
 tornado==6.3.2
     # via distributed
 tqdm==4.65.0
@@ -440,58 +249,26 @@ tqdm==4.65.0
     #   -r requirements.in
     #   huggingface-hub
     #   lancedb
-    #   lightning
     #   openai
-    #   pytorch-lightning
     #   transformers
-traitlets==5.9.0
-    # via lightning
 transformers==4.31.0
     # via -r requirements.in
 typer==0.9.0
     # via -r requirements.in
 typing-extensions==4.7.1
     # via
-    #   fastapi
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   pydantic
-    #   pytorch-lightning
     #   readerwriterlock
-    #   rich
-    #   sqlalchemy
-    #   starlette
     #   torch
-    #   torchmetrics
     #   typer
-    #   typing-inspect
-    #   uvicorn
-typing-inspect==0.9.0
-    # via dataclasses-json
 tzdata==2023.3
     # via pandas
-ujson==5.8.0
-    # via pymilvus
 urllib3==1.26.16
     # via
     #   botocore
     #   distributed
-    #   lightning
-    #   lightning-cloud
     #   requests
-uvicorn==0.23.1
-    # via
-    #   lightning
-    #   lightning-cloud
-wcwidth==0.2.6
-    # via blessed
-websocket-client==1.6.1
-    # via
-    #   lightning
-    #   lightning-cloud
-websockets==11.0.3
-    # via lightning
 werkzeug==2.3.6
     # via
     #   -r requirements.in
@@ -501,9 +278,4 @@ yarl==1.9.2
 zict==3.0.0
     # via distributed
 zipp==3.16.2
-    # via
-    #   importlib-metadata
-    #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+    # via importlib-metadata

--- a/superduperdb/misc/config.py
+++ b/superduperdb/misc/config.py
@@ -91,8 +91,8 @@ class LogType(str, Enum):
 class Logging(JSONable):
     """Describe how we are going to log. This isn't yet used."""
 
-    level = LogLevel.INFO
-    type = LogType.STDERR
+    level: LogLevel = LogLevel.INFO
+    type: LogType = LogType.STDERR
     kwargs: dict = Factory(dict)
 
 
@@ -137,10 +137,8 @@ class Notebook(JSONable):
     port: int = 8888
     token: str = ''
 
-    @root_validator
-    def check_one_or_none(
-        cls, v: t.Dict[str, t.Union[str, int]]
-    ) -> t.Dict[str, t.Union[str, int]]:
+    @root_validator(skip_on_failure=True)  # type: ignore[call-overload]
+    def check_one_or_none(cls, v: t.Dict) -> t.Dict:
         if v['password'] and v['token']:
             raise ValueError('At most one of password and token may be set')
         return v


### PR DESCRIPTION
## Description

https://github.com/SuperDuperDB/superduperdb-stealth/pull/565 changed requirements.txt but did not regenerate the dependencies!

This pull request fixes that, and then updates to the long-awaited `pydantic` 2 which we are finally able to install.

(We aren't using any Pydantic 2 features yet, and we should probably let it sit for a bit before we do in case we suddenly have to backgrade.)