### PR TITLE
Get rid of import spam on startup

### DIFF
--- a/superduperdb/cli/serve.py
+++ b/superduperdb/cli/serve.py
@@ -1,29 +1,33 @@
 import typing as t
 
-from superduperdb import CFG
-from superduperdb.db.base.build import build_datalayer
-from superduperdb.db.base.cdc import DatabaseWatcher
-from superduperdb.db.mongodb.query import Collection
-from superduperdb.server.dask_client import dask_client
-from superduperdb.server.server import serve as _serve
+import superduperdb as s
 
 from . import command
 
 
 @command(help='Start server')
 def serve():
+    from superduperdb.db.base.build import build_datalayer
+    from superduperdb.server.server import serve
+
     db = build_datalayer()
-    _serve(db)
+    serve(db)
 
 
 @command(help='Start local cluster: server, dask and change data capture')
 def local_cluster(on: t.List[str] = []):
+    from superduperdb.db.base.build import build_datalayer
+    from superduperdb.db.base.cdc import DatabaseWatcher
+    from superduperdb.db.mongodb.query import Collection
+    from superduperdb.server.dask_client import dask_client
+    from superduperdb.server.server import serve
+
     db = build_datalayer()
-    dask_client(CFG.dask, local=True)
+    dask_client(s.CFG.dask, local=True)
     for collection in on:
         w = DatabaseWatcher(
             db=db,
             on=Collection(name=collection),
         )
         w.watch()
-    _serve(db)
+    serve(db)


### PR DESCRIPTION
## Description

`faiss` is always loaded, resulting in unnecessary printing and 2 seconds delay if we don't use it.  This fixes that.