### PR TITLE
Use autodiscovery for build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["superduperdb"]
-
 [project]
 name = "superduperdb"
 description = "🔮 Super-power your database with AI 🔮"


### PR DESCRIPTION
## Description

This fixes the build - previously only `__init__.py` and `__main__.py` were included, whereas now (with the default autodiscovery behaviour of `setuptools`) all modules are included.

## Related Issue(s)

N/A

## Checklist

N/A

## Additional Notes

N/A



