### PR TITLE
ci: add pipeline to fetch and aggregate the repo usages data

### DIFF
--- a/.github/workflows/repo-usage-stats.yaml
+++ b/.github/workflows/repo-usage-stats.yaml
@@ -12,4 +12,4 @@ jobs:
       - uses: jgehrcke/github-repo-stats@HEAD
         with:
           repository: SuperDuperDB/superduperdb
-          ghtoken: ${{ secrets.GITHUB_TOKEN }}
+          ghtoken: ${{ secrets.GH_TOKEN_ANALYTICS }}

--- a/.github/workflows/repo-usage-stats.yaml
+++ b/.github/workflows/repo-usage-stats.yaml
@@ -11,5 +11,4 @@ jobs:
     steps:
       - uses: jgehrcke/github-repo-stats@HEAD
         with:
-          repository: SuperDuperDB/superduperdb
           ghtoken: ${{ secrets.GH_TOKEN_ANALYTICS }}

--- a/.github/workflows/repo-usage-stats.yaml
+++ b/.github/workflows/repo-usage-stats.yaml
@@ -1,0 +1,15 @@
+name: "Repo usage stats"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  calculate-stats:
+    runs-on: ubuntu-22.04
+    environment: "analytics"
+    steps:
+      - uses: jgehrcke/github-repo-stats@HEAD
+        with:
+          repository: SuperDuperDB/superduperdb
+          ghtoken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

Added the CI job to fetch and aggregate the repo usage data on a daily basis.

## Why do we need it

To keep track of KPIs.

## ⚠️ Blockers

- [x] The secret `GH_TOKEN_ANALYTICS` with the scope `repo` must be configured in the repo secrets for the environment `analytics`
