### PR TITLE
Update actions for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,8 +37,36 @@ jobs:
         with:
           path: ./dist
 
-  create-release:
+  test-build:
     needs: ['build']
+    # TODO: decide whether it's worth it to run tests on multiple OSes
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+              
+        # Artifacts located in artifact/
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+
+      - name: install wheel
+        run: pip install artifact/dist/*.whl
+
+        # This checks that all modules can be imported correctly
+      - name: test imports
+        run: python -m pytest test/unittest/test_impall.py
+      
+      - name: test CLI
+        run: python -m superduperdb
+  
+  create-release:
+    needs: ['test-build']
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test-deps.yml
+++ b/.github/workflows/test-deps.yml
@@ -1,0 +1,89 @@
+name: test dependencies
+
+on:
+  schedule:
+    # Triggers the workflow every day at 0130 UTC
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+    test-nodevdeps:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+              # "macos-latest" removed for now as Docker action is slow
+              os: [ "ubuntu-latest" ]  # TODO: add "windows-latest"
+              python-version: ["3.8", "3.9", "3.10"]
+        defaults:
+            run:
+              shell: bash
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v3
+
+            - name: Set up Python ${{ matrix.python-version }}
+              id: setup-python
+              uses: actions/setup-python@v4
+              with:
+                python-version: ${{ matrix.python-version }}
+
+            - name: Install core dependencies only
+              run: python -m pip install .
+
+            # TODO: vendor only the parts that we need from the following action
+            - name: Docker
+              if: ${{ matrix.os == 'macos-latest' }}
+              uses: douglascamata/setup-docker-macos-action@5f13b5b88a09467c10f8462810902b60ff70fb75
+
+            # This checks that all modules can be imported correctly
+            - name: test imports
+              run: python -m pytest test/unittest/test_impall.py
+
+            - name: test CLI
+              run: python -m superduperdb
+
+    test-devdeps:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+            # "macos-latest" removed for now as Docker action is slow
+              os: [ "ubuntu-latest" ]  # TODO: add "windows-latest"
+              python-version: ["3.8", "3.9", "3.10"]
+        defaults:
+            run:
+              shell: bash
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v3
+
+            - name: Set up Python ${{ matrix.python-version }}
+              id: setup-python
+              uses: actions/setup-python@v4
+              with:
+                python-version: ${{ matrix.python-version }}
+
+            - name: Install developer dependencies
+              run: python -m pip install requirements/requirements-dev.in
+
+            # TODO: vendor only the parts that we need from the following action
+            - name: Docker
+              if: ${{ matrix.os == 'macos-latest' }}
+              uses: douglascamata/setup-docker-macos-action@5f13b5b88a09467c10f8462810902b60ff70fb75
+
+            - name: lint and test
+              run: |
+                make lint
+                make test
+
+    slack-notify:
+        needs: [test-nodevdeps, test-devdeps]
+        runs-on: ubuntu-latest
+        # https://stackoverflow.com/questions/71430668/how-to-run-a-github-actions-job-on-workflow-failure
+        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        steps:
+            - name: Send GitHub Action trigger data to Slack workflow
+              uses: slackapi/slack-github-action@v1.24.0
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

This PR adds two new actions related to our release process. `test-deps.yml` checks whether any new release of packages that we depend on will break our package. `release.yaml` builds a wheel and then installs the wheel and checks that imports and CLI are working correctly.

**More details:**

- `test-deps.yml` does a fresh install with the latest version of all our (i) core dependencies and (ii) developer dependencies, and then checks that imports, CLI and tests all work correctly. This is currently a nightly cron job as it takes a while for `pip` to resolve and install the latest version of our dependencies. Failures will be sent to Slack.

- `release.yaml` builds our package, and then installs it and checks that CLI and imports are working correctly. It only does this for CPython 3.10 and one platform (Ubuntu) because it will make the action very slow otherwise (but this can be changed)

## Related Issues

#607 


## Checklist

N/A

## Additional Notes or Comments

This is still quite rough. Improvements are very weclome!

This requires an admin to create a secret with a Slack webhook URL. Please contact me for details.
