### PR TITLE
Add tenacity as core dep

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -16,8 +16,6 @@ alabaster==0.7.13
     # via sphinx
 anyio==3.7.1
     # via httpcore
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
@@ -78,6 +76,8 @@ cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
+cmake==3.27.1
+    # via triton
 colorama==0.4.6
     # via interrogate
 coverage[toml]==7.2.7
@@ -124,6 +124,7 @@ filelock==3.12.2
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 flask==2.3.2
     # via
     #   -r requirements.in
@@ -219,6 +220,8 @@ lancedb==0.1.10
     # via -r requirements.in
 libcst==1.0.1
     # via monkeytype
+lit==16.0.6
+    # via triton
 locket==1.0.0
     # via
     #   distributed
@@ -291,6 +294,31 @@ numpy==1.24.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 openai==0.27.8
     # via -r requirements.in
 overrides==7.3.1
@@ -492,7 +520,7 @@ tblib==2.0.0
 tdir==1.6.0
     # via -r requirements-test.in
 tenacity==8.2.2
-    # via -r requirements-test.in
+    # via -r requirements.in
 threadpoolctl==3.2.0
     # via scikit-learn
 tinycss2==1.2.1
@@ -519,6 +547,7 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
+    #   triton
 tornado==6.3.2
     # via
     #   distributed
@@ -542,6 +571,8 @@ traitlets==5.9.0
     #   nbsphinx
 transformers==4.31.0
     # via -r requirements.in
+triton==2.0.0
+    # via torch
 typer==0.9.0
     # via -r requirements.in
 types-awscrt==0.16.25
@@ -592,7 +623,14 @@ werkzeug==2.3.6
     #   -r requirements.in
     #   flask
 wheel==0.40.0
-    # via pip-tools
+    # via
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
+    #   pip-tools
 xmod==1.5.0
     # via
     #   dek

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -6,8 +6,6 @@
 #
 alabaster==0.7.13
     # via sphinx
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 attrs==23.1.0

--- a/requirements/requirements-test.in
+++ b/requirements/requirements-test.in
@@ -3,6 +3,5 @@ httpx>=0.24.1
 impall>=1.2.0
 lorem>=0.1.1
 pytest>=7.3.1
-tenacity>=8.1.0
 pytest-cov>=2.12.1
 tdir>=1.6

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -47,6 +47,8 @@ cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
+cmake==3.27.1
+    # via triton
 coverage[toml]==7.2.7
     # via pytest-cov
 dask[distributed]==2023.5.0
@@ -78,6 +80,7 @@ filelock==3.12.2
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 flask==2.3.2
     # via
     #   -r requirements.in
@@ -134,6 +137,8 @@ joblib==1.3.1
     # via scikit-learn
 lancedb==0.1.10
     # via -r requirements.in
+lit==16.0.6
+    # via triton
 locket==1.0.0
     # via
     #   distributed
@@ -166,6 +171,31 @@ numpy==1.24.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 openai==0.27.8
     # via -r requirements.in
 overrides==7.3.1
@@ -264,7 +294,7 @@ tblib==2.0.0
 tdir==1.6.0
     # via -r requirements-test.in
 tenacity==8.2.2
-    # via -r requirements-test.in
+    # via -r requirements.in
 threadpoolctl==3.2.0
     # via scikit-learn
 tokenizers==0.13.3
@@ -282,6 +312,7 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
+    #   triton
 tornado==6.3.2
     # via distributed
 tqdm==4.65.0
@@ -293,6 +324,8 @@ tqdm==4.65.0
     #   transformers
 transformers==4.31.0
     # via -r requirements.in
+triton==2.0.0
+    # via torch
 typer==0.9.0
     # via -r requirements.in
 typing-extensions==4.7.1
@@ -313,6 +346,14 @@ werkzeug==2.3.6
     # via
     #   -r requirements.in
     #   flask
+wheel==0.41.1
+    # via
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
 xmod==1.5.0
     # via
     #   dek
@@ -323,3 +364,6 @@ zict==3.0.0
     # via distributed
 zipp==3.16.2
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -24,3 +24,4 @@ torch>=2.0.0,!=2.0.1
 transformers>=4.29.1
 accelerate>=0.20.1
 overrides>=7
+tenacity>=8.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -46,6 +46,8 @@ cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
+cmake==3.27.1
+    # via triton
 dask[distributed]==2023.5.0
     # via
     #   -r requirements.in
@@ -69,6 +71,7 @@ filelock==3.12.2
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 flask==2.3.2
     # via
     #   -r requirements.in
@@ -116,6 +119,8 @@ joblib==1.3.1
     # via scikit-learn
 lancedb==0.1.10
     # via -r requirements.in
+lit==16.0.6
+    # via triton
 locket==1.0.0
     # via
     #   distributed
@@ -146,6 +151,31 @@ numpy==1.24.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 openai==0.27.8
     # via -r requirements.in
 overrides==7.3.1
@@ -231,6 +261,8 @@ sympy==1.12
     # via torch
 tblib==2.0.0
     # via distributed
+tenacity==8.2.2
+    # via -r requirements.in
 threadpoolctl==3.2.0
     # via scikit-learn
 tokenizers==0.13.3
@@ -244,6 +276,7 @@ torch==2.0.0
     # via
     #   -r requirements.in
     #   accelerate
+    #   triton
 tornado==6.3.2
     # via distributed
 tqdm==4.65.0
@@ -255,6 +288,8 @@ tqdm==4.65.0
     #   transformers
 transformers==4.31.0
     # via -r requirements.in
+triton==2.0.0
+    # via torch
 typer==0.9.0
     # via -r requirements.in
 typing-extensions==4.7.1
@@ -275,9 +310,20 @@ werkzeug==2.3.6
     # via
     #   -r requirements.in
     #   flask
+wheel==0.41.1
+    # via
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
 yarl==1.9.2
     # via aiohttp
 zict==3.0.0
     # via distributed
 zipp==3.16.2
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

`tenacity` is actually a core dependency (eg `superduperdb/ext/misc/retry.py`) and not just a development dependency. This PR fixes the relevant requirements files to update this.

At the moment the package breaks if we try to use the OpenAI functionality.


## Related Issues

None

## Checklist

N/A

## Additional Notes or Comments