### PR TITLE
Add example illustrating canonical question-the-docs

### DIFF
--- a/docs/examples/question-the-docs.ipynb
+++ b/docs/examples/question-the-docs.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c042ddbb-c2c9-46ed-b36c-c965c0d7ff5b",
+   "metadata": {},
+   "source": [
+    "# Ask the docs anything about SuperDuperDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f5bcdade-f988-4464-bfcf-806245031bb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['OPENAI_API_KEY'] = '<YOUR-OPENAI-API-KEY>'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f42c42cc-af6a-4712-a993-d9c921693819",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from superduperdb import superduper\n",
+    "from superduperdb.db.mongodb.query import Collection\n",
+    "import pymongo\n",
+    "\n",
+    "db = pymongo.MongoClient().documents\n",
+    "db = superduper(db)\n",
+    "\n",
+    "collection = Collection('questiondocs')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d72a2a52-964f-456e-88b6-040965f5ed1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "\n",
+    "STRIDE = 5       # stride in numbers of lines\n",
+    "WINDOW = 10       # length of window in numbers of lines\n",
+    "\n",
+    "content = sum([open(file).readlines() for file in glob.glob('../*/*.md') + glob.glob('../*.md')], [])\n",
+    "chunks = ['\\n'.join(content[i: i + WINDOW]) for i in range(0, len(content), STRIDE)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "34a3a6ef-6cba-4655-9822-0ea4f9151f9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "- We have data in production populated by users accessing a popular website, and which sends JSON records to MongoDB, with references to web URLs hosted on a separate image server.\n",
+       "\n",
+       "- Each record contains some data left behind by users which may be useful for training a classification model.\n",
+       "\n",
+       "\n",
+       "\n",
+       "Given this data, we would like to accomplish the following:\n",
+       "\n",
+       "\n",
+       "\n",
+       "- We would like to use our data hosted in MongoDB to train a model to classify images\n",
+       "\n",
+       "- We want to use the probabilistic estimates for the classifications in a production scenario\n",
+       "\n",
+       "\n",
+       "\n",
+       "To do this, we need to be able to implement these high level steps:\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import Markdown\n",
+    "Markdown(chunks[2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a7208ef2-c035-43b9-a624-ade42a06ed09",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:found 0 uris\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(<pymongo.results.InsertManyResult at 0x110ecc490>,\n",
+       " TaskWorkflow(database=<superduperdb.db.base.db.DB object at 0x19b248dc0>, G=<networkx.classes.digraph.DiGraph object at 0x110edb460>))"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from superduperdb.container.document import Document\n",
+    "\n",
+    "db.execute(collection.insert_many([Document({'txt': chunk}) for chunk in chunks]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "083ccfdd-0ac1-4749-8c74-857d43eeba5f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Document({'_id': ObjectId('64d750f0606e13d1ad232b38'), 'txt': \"# Common issues in AI-data development\\n\\n\\n\\nTraditionally, AI development and databases have lived in separate silo-ed worlds, which \\n\\nonly interact as an afterthought at the point where a production system is required to \\n\\napply an AI model to a row or table in a database and store and serve the resulting predictions.\\n\\n\\n\\nLet's see how this can play out in practice.\\n\\n\\n\\nSuppose our situation is as follows:\\n\\n\\n\", '_fold': 'train'})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.execute(collection.find_one())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1aa132d0-e6a2-46f6-9eb8-13fbce90ff11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:model/text-embedding-ada-002/0 already exists - doing nothing\n",
+      "WARNING:root:model/text-embedding-ada-002/0 already exists - doing nothing\n",
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:07<00:00,  1.81s/it]\n",
+      "INFO:root:loading hashes: 'my-index'\n",
+      "Loading vectors into vector-table...: 375it [00:00, 924.50it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from superduperdb.container.vector_index import VectorIndex\n",
+    "from superduperdb.container.listener import Listener\n",
+    "from superduperdb.ext.openai.model import OpenAIEmbedding\n",
+    "\n",
+    "db.add(\n",
+    "    VectorIndex(\n",
+    "        identifier='my-index',\n",
+    "        indexing_listener=Listener(\n",
+    "            model=OpenAIEmbedding(model='text-embedding-ada-002'),\n",
+    "            key='txt',\n",
+    "            select=collection.find(),\n",
+    "        ),\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "abfa4df6-73ac-4d46-8047-011648e24958",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['gpt-3.5-turbo', 'text-embedding-ada-002']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from superduperdb.ext.openai.model import OpenAIChatCompletion\n",
+    "\n",
+    "chat = OpenAIChatCompletion(\n",
+    "    model='gpt-3.5-turbo',\n",
+    "    prompt=(\n",
+    "        'Use the following description and code-snippets aboout SuperDuperDB to answer this question about SuperDuperDB\\n'\n",
+    "        'Do not use any other information you might have learned about other python packages\\n'\n",
+    "        'Only base your answer on the code-snippets retrieved\\n'\n",
+    "        '{context}\\n\\n'\n",
+    "        'Here\\'s the question:\\n'\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "db.add(chat)\n",
+    "\n",
+    "print(db.show('model'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "a6cde11c-6c7e-457d-8031-873acaca600c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 2]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.show('model', 'gpt-3.5-turbo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "fc4a0f6c-9e24-47aa-bc73-7cc4507e94ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Sure! Here's a code snippet to set up a `VectorIndex`:\n",
+       "\n",
+       "```python\n",
+       "from superduperdb.container.vector_index import VectorIndex\n",
+       "from superduperdb.core.listener import listener\n",
+       "\n",
+       "# First, define a listener to keep vectors up-to-date\n",
+       "indexing_listener = listener(model=OpenAIEmbedding(), key='text', select=collection.find())\n",
+       "\n",
+       "# Then, create a VectorIndex and link it with the indexing listener\n",
+       "db.add(VectorIndex('my-index', indexing_listener=indexing_listener))\n",
+       "```\n",
+       "\n",
+       "This code snippet sets up a `VectorIndex` named `'my-index'` and associates it with an indexing listener that uses a model called `OpenAIEmbedding`. The indexing listener will ensure that the vectors stay up-to-date."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from superduperdb.container.document import Document\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "\n",
+    "q = 'Can you give me a code-snippet to set up a `VectorIndex`?'\n",
+    "\n",
+    "output, context = db.predict(\n",
+    "    model='gpt-3.5-turbo',\n",
+    "    input=q,\n",
+    "    context_select=(\n",
+    "        collection\n",
+    "            .like(Document({'txt': q}), vector_index='my-index', n=5)\n",
+    "            .find()\n",
+    "    ),\n",
+    "    context_key='txt',\n",
+    ")\n",
+    "\n",
+    "Markdown(output.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -248,14 +248,14 @@ into the database.
 An equivalent syntax is the following:
 
 ```python
->>> from superduperdb.core.listener import listener
+>>> from superduperdb.container.listener import listener
 >>> db.add(
-    listener(
-        model=model,
-        select=coll.find(),
-        key='input_col',
-    )
-)
+...    listener(
+...        model=model,
+...        select=coll.find(),
+...        key='input_col',
+...    )
+... )
 ```
 
 After setting up a `listener`, whenever data is inserted or updated, jobs are created 

--- a/docs/usage/vector_index.md
+++ b/docs/usage/vector_index.md
@@ -29,7 +29,7 @@ The model `my-model` should have already been registered with SuperDuperDB (see 
 See [here](listener) for how to create such a component.
 
 Alternatively the model and listener may be created inline. 
-Here is how to define a simple libear bag-of-words model:
+Here is how to define a simple linear bag-of-words model:
 
 ```python
 from superduperdb.container.vector_index import VectorIndex
@@ -53,9 +53,8 @@ db.add(
                 preprocess=TextEmbedding(d),  # "d" should be loaded from disk
                 object=torch.nn.Linear(64, 512),
             )
-key = '<key-to-search>',
-)
-)
+        key = '<key-to-search>',
+    )
 )
 ```
 
@@ -66,12 +65,12 @@ To use your vector index to search MongoDB, there are two possibilities:
 Firstly, find similar matches and then filter the results:
 
 ```python
->> > from superduperdb.container.document import Document as D
->> > db.execute(
-    ...
-Collection('my-coll')
-....like(D({'<key-to-search>': '<content' >}), vector_index='my-index')
-....find( < filter >, < projection >)
+>>> from superduperdb.container.document import Document as D
+>>> db.execute(
+...    Collection('my-coll')
+...       .like(D({'<key-to-search>': '<content' >}, vector_index='my-index')
+...       .find( < filter >, < projection >)
+...    )
 ... )
 ```
 

--- a/superduperdb/db/base/artifact.py
+++ b/superduperdb/db/base/artifact.py
@@ -30,7 +30,7 @@ class ArtifactStore(ABC):
         pass
 
     @abstractmethod
-    def drop(self):
+    def drop(self, force: bool = False):
         """
         Drop the artifact store.
         """

--- a/superduperdb/db/base/data_backend.py
+++ b/superduperdb/db/base/data_backend.py
@@ -20,7 +20,7 @@ class BaseDataBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def drop(self, force=False):
+    def drop(self, force: bool = False):
         """
         Drop the databackend.
         """

--- a/superduperdb/db/base/db.py
+++ b/superduperdb/db/base/db.py
@@ -98,11 +98,11 @@ class DB:
     def distributed_client(self):
         return self._distributed_client
 
-    def drop(self):
+    def drop(self, force: bool = False):
         """
         Drop all data, artifacts and metadata
         """
-        if not click.confirm(
+        if not force and not click.confirm(
             f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
             f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
             'Are you sure you want to drop the database? ',

--- a/superduperdb/db/base/metadata.py
+++ b/superduperdb/db/base/metadata.py
@@ -32,7 +32,7 @@ class MetaDataStore(ABC):
         pass
 
     @abstractmethod
-    def drop(self):
+    def drop(self, force: bool = False):
         """
         Drop the metadata store.
         """

--- a/superduperdb/db/mongodb/artifacts.py
+++ b/superduperdb/db/mongodb/artifacts.py
@@ -15,14 +15,15 @@ class MongoArtifactStore(ArtifactStore):
         self.db = self.conn[self.name]
         self.filesystem = gridfs.GridFS(self.db)
 
-    def drop(self):
-        if not click.confirm(
-            f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
-            f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
-            'Are you sure you want to drop the data-backend? ',
-            default=False,
-        ):
-            print('Aborting...')
+    def drop(self, force: bool = False):
+        if not force:
+            if not click.confirm(
+                f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
+                f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
+                'Are you sure you want to drop all artifacts? ',
+                default=False,
+            ):
+                print('Aborting...')
         return self.db.client.drop_database(self.db.name)
 
     def delete_artifact(self, file_id: str):

--- a/superduperdb/db/mongodb/data_backend.py
+++ b/superduperdb/db/mongodb/data_backend.py
@@ -22,14 +22,15 @@ class MongoDataBackend(BaseDataBackend):
     def db(self):
         return self._db
 
-    def drop(self):
-        if not click.confirm(
-            f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
-            f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
-            'Are you sure you want to drop the data-backend? ',
-            default=False,
-        ):
-            print('Aborting...')
+    def drop(self, force: bool = False):
+        if not force:
+            if not click.confirm(
+                f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
+                f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
+                'Are you sure you want to drop the data-backend? ',
+                default=False,
+            ):
+                print('Aborting...')
         return self.db.client.drop_database(self.db.name)
 
     def get_output_from_document(

--- a/superduperdb/db/mongodb/metadata.py
+++ b/superduperdb/db/mongodb/metadata.py
@@ -21,14 +21,15 @@ class MongoMetaDataStore(MetaDataStore):
         self.job_collection = self.db['_jobs']
         self.parent_child_mappings = self.db['_parent_child_mappings']
 
-    def drop(self):
-        if not click.confirm(
-            f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
-            f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
-            'Are you sure you want to drop the data-backend? ',
-            default=False,
-        ):
-            print('Aborting...')
+    def drop(self, force: bool = False):
+        if not force:
+            if not click.confirm(
+                f'{Colors.RED}[!!!WARNING USE WITH CAUTION AS YOU '
+                f'WILL LOSE ALL DATA!!!]{Colors.RESET} '
+                'Are you sure you want to drop all meta-data? ',
+                default=False,
+            ):
+                print('Aborting...')
         self.db.drop_collection(self.meta_collection.name)
         self.db.drop_collection(self.object_collection.name)
         self.db.drop_collection(self.job_collection.name)


### PR DESCRIPTION
Here's a simple example illustrating the popular question-the-docs use-case.

**Changes from current approach**

The differences to the current app we've experimented are:

- Content in raw markdown, split line-by-line (not word-by-word)
- Big chunks

**Findings**

- The number of similar results makes a big difference `.like(..., n=?)`
- The code-snippets are better respected using markdown content