### PR TITLE
Feature/predict missing ids

### DIFF
--- a/superduperdb/db/base/query.py
+++ b/superduperdb/db/base/query.py
@@ -60,7 +60,17 @@ class Select(ABC, Serializable):
 
         :param ids: string ids to which subsetting should occur
         """
-        pass
+        raise NotImplementedError
+
+    def select_ids_of_missing_outputs(self, key: str, model: str) -> 'Select':
+        """
+        Create a select which selects the ids of documents whose
+        `_outputs.key.model` entries are missing
+
+        :param key: key on which model was applied
+        :param model: model identifier
+        """
+        raise NotImplementedError
 
     def add_fold(self, fold: str) -> 'Select':
         """Create a select which selects the same data, but additionally restricts to

--- a/test/unittest/db/mongodb/test_query.py
+++ b/test/unittest/db/mongodb/test_query.py
@@ -1,0 +1,19 @@
+from superduperdb.container.document import Document
+from superduperdb.db.mongodb import query as q
+
+
+def test_select_missing_outputs(random_data):
+    docs = list(random_data.execute(q.Collection('documents').find({}, {'_id': 1})))
+    ids = [r['_id'] for r in docs[: len(docs) // 2]]
+    random_data.execute(
+        q.Collection('documents').update_many(
+            {'_id': {'$in': ids}},
+            Document({'$set': {'_outputs.x.test_model_output': 'test'}}),
+        )
+    )
+
+    select = q.Collection('documents').find({}, {'_id': 1})
+    modified_select = select.select_ids_of_missing_outputs('x', 'test_model_output')
+
+    out = list(random_data.execute(modified_select))
+    assert len(out) == (len(docs) - len(ids))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

- Add the method `Select.select_ids_of_missing_outputs` to make `Model.predict` less redundant.
- Implementation for MongoDB
- Modify `Model.predict` to use this
