### PR TITLE
Fix model/key splitting (fix #741)

### DIFF
--- a/superduperdb/db/base/db.py
+++ b/superduperdb/db/base/db.py
@@ -531,7 +531,7 @@ class DB:
         for identifier in listener:
             info = self.metadata.get_component('listener', identifier)
             query = info['dict']['select']
-            model, key = identifier.split('/')
+            model, _, key = identifier.rpartition('/')
             G.add_node(
                 f'{model}.predict({key})',
                 job=ComponentJob(
@@ -548,7 +548,7 @@ class DB:
             )
 
         for identifier in listener:
-            model, key = identifier.split('/')
+            model, _, key = identifier.rpartition('/')
             G.add_edge(
                 f'{download_content.__name__}()',
                 f'{model}.predict({key})',
@@ -557,7 +557,7 @@ class DB:
                 identifier
             )  # TODO remove features as explicit argument to listener
             for dep in deps:
-                dep_model, dep_key = dep.split('/')
+                dep_model, _, dep_key = dep.rpartition('/')
                 G.add_edge(
                     f'{dep_model}.predict({dep_key})',
                     f'{model}.predict({key})',

--- a/superduperdb/db/mongodb/cdc.py
+++ b/superduperdb/db/mongodb/cdc.py
@@ -162,7 +162,7 @@ def copy_vectors(
         select = query.select_using_ids(ids)
         docs = db.select(select)
         docs = [doc.unpack() for doc in docs]
-        model, key = indexing_listener_identifier.split('/')
+        model, _, key = indexing_listener_identifier.rpartition('/')
         vectors = [
             {'vector': doc['_outputs'][key][model], 'id': str(doc['_id'])}
             for doc in docs
@@ -271,9 +271,8 @@ class CDCHandler(threading.Thread):
                 ),
             )
         if task != 'delete':
-            model, key = indexing_listener_identifier.split(  # type: ignore[union-attr]
-                '/'
-            )
+            assert indexing_listener_identifier
+            model, _, key = indexing_listener_identifier.rpartition('/')
             task_workflow.add_edge(
                 f'{model}.predict({key})',
                 f'{task_name}({indexing_listener_identifier})',


### PR DESCRIPTION
This passes the unit tests.

The extremely clear test program provided (thanks!) seems to get farther and then dies because it can't reach a server, transcript below: I don't think that's anything to do with the fix.

The missing part is a unit test to prevent regressions, I'm not quite sure how to do that...?

```
INFO:sentence_transformers.SentenceTransformer:Load pretrained SentenceTransformer: BAAI/bge-base-en
Downloading (…)5de97/.gitattributes: 100%|████████████████████████████████████████████████████████| 1.52k/1.52k [00:00<00:00, 699kB/s]
Downloading (…)_Pooling/config.json: 100%|████████████████████████████████████████████████████████████| 190/190 [00:00<00:00, 124kB/s]
Downloading (…)c37f85de97/README.md: 100%|████████████████████████████████████████████████████████| 78.7k/78.7k [00:00<00:00, 984kB/s]
Downloading (…)7f85de97/config.json: 100%|███████████████████████████████████████████████████████████| 719/719 [00:00<00:00, 3.43MB/s]
Downloading (…)ce_transformers.json: 100%|████████████████████████████████████████████████████████████| 124/124 [00:00<00:00, 342kB/s]
Downloading model.safetensors: 100%|███████████████████████████████████████████████████████████████| 438M/438M [00:12<00:00, 35.0MB/s]
Downloading pytorch_model.bin: 100%|███████████████████████████████████████████████████████████████| 438M/438M [00:12<00:00, 35.3MB/s]
Downloading (…)nce_bert_config.json: 100%|██████████████████████████████████████████████████████████| 52.0/52.0 [00:00<00:00, 223kB/s]
Downloading (…)cial_tokens_map.json: 100%|████████████████████████████████████████████████████████████| 125/125 [00:00<00:00, 610kB/s]
Downloading (…)5de97/tokenizer.json: 100%|█████████████████████████████████████████████████████████| 711k/711k [00:00<00:00, 2.13MB/s]
Downloading (…)okenizer_config.json: 100%|███████████████████████████████████████████████████████████| 366/366 [00:00<00:00, 1.77MB/s]
Downloading (…)c37f85de97/vocab.txt: 100%|█████████████████████████████████████████████████████████| 232k/232k [00:00<00:00, 13.1MB/s]
Downloading (…)f85de97/modules.json: 100%|████████████████████████████████████████████████████████████| 229/229 [00:00<00:00, 935kB/s]
INFO:torch.distributed.nn.jit.instantiator:Created a temporary directory at /var/folders/wr/yxfbw4xn6p3df3d7dqjp_kz00000gn/T/tmpem05mkkp
INFO:torch.distributed.nn.jit.instantiator:Writing /var/folders/wr/yxfbw4xn6p3df3d7dqjp_kz00000gn/T/tmpem05mkkp/_remote_module_non_scriptable.py
INFO:sentence_transformers.SentenceTransformer:Use pytorch device: cpu
Traceback (most recent call last):
  File "test_program.py", line 51, in <module>
    db.add(
  File "/Users/tom/synthetic/code/superduperdb/superduperdb/db/base/db.py", line 379, in add
    return self._add(
  File "/Users/tom/synthetic/code/superduperdb/superduperdb/db/base/db.py", line 606, in _add
    existing_versions = self.show(
  File "/Users/tom/synthetic/code/superduperdb/superduperdb/db/base/db.py", line 161, in show
    return self.metadata.show_component_versions(
  File "/Users/tom/synthetic/code/superduperdb/superduperdb/db/mongodb/metadata.py", line 113, in show_component_versions
    return self.object_collection.distinct(
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/collection.py", line 2775, in distinct
    return self._retryable_non_cursor_read(_cmd, session)
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/collection.py", line 1858, in _retryable_non_cursor_read
    with client._tmp_session(session) as s:
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1775, in _tmp_session
    s = self._ensure_session(session)
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1758, in _ensure_session
    return self.__start_session(True, causal_consistency=False)
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1703, in __start_session
    self._topology._check_implicit_session_support()
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/topology.py", line 538, in _check_implicit_session_support
    self._check_session_support()
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/topology.py", line 554, in _check_session_support
    self._select_servers_loop(
  File "/Users/tom/synthetic/code/superduperdb/.direnv/python-3.8/lib/python3.8/site-packages/pymongo/topology.py", line 238, in _select_servers_loop
    raise ServerSelectionTimeoutError(
pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused, Timeout: 30s, Topology Description: <TopologyDescription id: 64e46d1368e5b5c609184c1b, topology_type: Unknown, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('localhost:27017: [Errno 61] Connection refused')>]>

```