### PR TITLE
Use ruff.isort and remove isort package

### DIFF
--- a/.github/ci-pinned-requirements/dev.txt
+++ b/.github/ci-pinned-requirements/dev.txt
@@ -231,10 +231,6 @@ interrogate==1.5.0
     # via superduperdb
 ipython==8.12.2
     # via superduperdb
-isort==5.12.0
-    # via
-    #   impall
-    #   superduperdb
 itsdangerous==2.1.2
     # via flask
 jedi==0.19.0

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ clean-test-containers:
 .PHONY: lint-and-type-check
 lint-and-type-check:
 	mypy superduperdb
-	isort --check $(DIRECTORIES)
 	black --check $(DIRECTORIES)
 	ruff check $(DIRECTORIES)
 	interrogate superduperdb
@@ -35,7 +34,6 @@ fix-and-test: test-containers
 test-and-fix: test-containers
 	mypy superduperdb
 	pytest $(PYTEST_ARGUMENTS)
-	isort $(DIRECTORIES)
 	black $(DIRECTORIES)
 	ruff check --fix $(DIRECTORIES)
 	interrogate superduperdb

--- a/apps/question-the-docs/backend/ai/artifacts.py
+++ b/apps/question-the-docs/backend/ai/artifacts.py
@@ -1,7 +1,6 @@
 from backend.ai.utils.github import URL_CACHE, save_github_md_files_locally
 from backend.ai.utils.text import chunk_file_contents
 from backend.config import settings
-
 from superduperdb.container.document import Document
 from superduperdb.db.mongodb.query import Collection
 

--- a/apps/question-the-docs/backend/ai/components.py
+++ b/apps/question-the-docs/backend/ai/components.py
@@ -1,5 +1,4 @@
 from backend.config import settings
-
 from superduperdb.container.listener import Listener
 from superduperdb.container.vector_index import VectorIndex
 from superduperdb.db.mongodb.query import Collection

--- a/apps/question-the-docs/backend/app.py
+++ b/apps/question-the-docs/backend/app.py
@@ -1,11 +1,11 @@
-from backend.ai.artifacts import load_ai_artifacts
-from backend.ai.components import install_ai_components
-from backend.config import settings
-from backend.documents.routes import documents_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pymongo import MongoClient
 
+from backend.ai.artifacts import load_ai_artifacts
+from backend.ai.components import install_ai_components
+from backend.config import settings
+from backend.documents.routes import documents_router
 from superduperdb import superduper
 
 

--- a/apps/question-the-docs/backend/documents/routes.py
+++ b/apps/question-the-docs/backend/documents/routes.py
@@ -1,10 +1,10 @@
 import typing as t
 
+from fastapi import APIRouter, Request
+
 from backend.ai.utils.github import repos
 from backend.config import settings
 from backend.documents.models import Answer, Query
-from fastapi import APIRouter, Request
-
 from superduperdb.db.mongodb.query import Collection
 
 documents_router = APIRouter(prefix='/documents', tags=['docs'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,6 @@ whitelist-regex = []
 extend-select = [
     "I", # Missing required import (auto-fixable)
 ]
+
+[tool.ruff.isort]
+combine-as-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ typing = [
 lint = [
     "black>=23.3",
     "interrogate>=1.5.0",
-    "isort>=5.12.0",
     "ruff>=0.0.267",
 ]
 tests = [
@@ -168,5 +167,7 @@ quiet = false
 verbose = 0
 whitelist-regex = []
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+extend-select = [
+    "I", # Missing required import (auto-fixable)
+]

--- a/superduperdb/db/ibis/field_types.py
+++ b/superduperdb/db/ibis/field_types.py
@@ -1,8 +1,7 @@
 import dataclasses as dc
 import typing as t
 
-from ibis.expr.datatypes import DataType
-from ibis.expr.datatypes import dtype as _dtype
+from ibis.expr.datatypes import DataType, dtype as _dtype
 
 
 @dc.dataclass

--- a/superduperdb/ext/openai/model.py
+++ b/superduperdb/ext/openai/model.py
@@ -3,8 +3,7 @@ import os
 import typing as t
 
 import tqdm
-from openai import ChatCompletion, Embedding
-from openai import Model as OpenAIModel
+from openai import ChatCompletion, Embedding, Model as OpenAIModel
 from openai.error import RateLimitError, ServiceUnavailableError, Timeout, TryAgain
 
 import superduperdb as s

--- a/superduperdb/ext/transformers/model.py
+++ b/superduperdb/ext/transformers/model.py
@@ -6,9 +6,13 @@ import re
 import typing as t
 import warnings
 
-from transformers import DataCollatorWithPadding, Trainer, TrainingArguments
-from transformers import Pipeline as BasePipeline
-from transformers import pipeline as _pipeline
+from transformers import (
+    DataCollatorWithPadding,
+    Pipeline as BasePipeline,
+    Trainer,
+    TrainingArguments,
+    pipeline as _pipeline,
+)
 
 from superduperdb.container.artifact import Artifact
 from superduperdb.container.metric import Metric

--- a/superduperdb/ext/transformers/model.py
+++ b/superduperdb/ext/transformers/model.py
@@ -6,9 +6,8 @@ import re
 import typing as t
 import warnings
 
-from transformers import DataCollatorWithPadding
+from transformers import DataCollatorWithPadding, Trainer, TrainingArguments
 from transformers import Pipeline as BasePipeline
-from transformers import Trainer, TrainingArguments
 from transformers import pipeline as _pipeline
 
 from superduperdb.container.artifact import Artifact

--- a/test/unittest/misc/test_dataclasses.py
+++ b/test/unittest/misc/test_dataclasses.py
@@ -1,7 +1,6 @@
 from dataclasses import InitVar, asdict, field, fields, replace
 
-from pydantic import Field
-from pydantic import dataclasses as dc
+from pydantic import Field, dataclasses as dc
 
 
 @dc.dataclass


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

Remove isort in our requirement and use ruff.isort, faster and reused ruff package

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
