### PR TITLE
Relax requests lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,12 @@ classifiers = [
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "boto3>=1.26.16",
+    "boto3>=1.16",
     "dask[distributed]>=2022.6.0",
     "dill>=0.3.6",
     "fil>=1.1.0",
     "networkx>=2.8.8",
-    "requests>=2.31.0",
+    "requests>=2.22",  # lower bound from openai and boto3
     "tqdm>=4.64.1",
     "typer>=0.7.0",
     "lancedb<0.2",  # TODO: Find a solution and unpin


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This PR relaxes the lower bound of `requests` in response to #788. 


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#788 

## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments

`openai` requires `requests>=2.20`. `openai` is a core dependency for us. It also has a huge user-base, and so is unlikely to relax this lower bound any further in the future in my opinion.

I also had to relax `boto3` because it is quite active in how it pins `urllib3` (a dependency of `requests`). The version I settled on for `boto3` is a bit arbitrary, but it allows all releases within the last 3 years, so hopefully that is enough. 
