### PR TITLE
Automate PyPI action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,3 +91,22 @@ jobs:
           artifact/*
         env:
           GH_TOKEN: ${{ github.token }}
+
+  publish-pypi:
+    needs: ['create-release']
+    # Environment waits for approval before attempting to upload to PyPI.
+    # This allows reviewing the files in the release on GitHub.
+    environment: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+      # Try uploading to Test PyPI first, in case something fails.
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: artifact/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: artifact/


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This PR automates the upload to PyPI. It relies on PyPAs [trusted publishing](https://docs.pypi.org/trusted-publishers/) implementation. This means that we do not need to attach any tokens etc to the environment.

A special environment ('publish-pypi') on GitHub for running the job will be created. Inside this environment there will be a requirement for a dev to approve one final time before uploading to PyPI. This means that the dev will have an opportunity to review the build artifact on GitHub (if they so wish) before uploading to PyPI. 


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#748 


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
