### PR TITLE
Remove many calls to sleep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ lightning_logs/
 /docs/source/
 /docs/examples/*.zip
 monkeytype.sqlite3
+
+test/sleep.json

--- a/superduperdb/db/base/download.py
+++ b/superduperdb/db/base/download.py
@@ -135,8 +135,6 @@ class BaseDownloader:
                     self._download(i)
             except TimeoutException:  # pragma: no cover
                 logging.warning(f'timed out {i}')
-            except KeyboardInterrupt:  # pragma: no cover
-                raise
             except Exception as e:  # pragma: no cover
                 if self.raises:
                     raise e
@@ -167,7 +165,7 @@ class BaseDownloader:
             logging.warning("--keyboard interrupt--")
             pool.terminate()
             pool.join()
-            sys.exit(1)
+            sys.exit(1)  # Kill this subprocess so it doesn't hang
 
         pool.close()
         pool.join()

--- a/superduperdb/db/base/metadata.py
+++ b/superduperdb/db/base/metadata.py
@@ -82,33 +82,28 @@ class MetaDataStore(ABC):
 
         :param identifier: job identifier
         """
-        try:
-            status = 'pending'
-            n_lines = 0
-            n_lines_stderr = 0
-            while status in {'pending', 'running'}:
-                r = self.get_job(identifier)
-                status = r['status']
-                if status == 'running':
-                    if len(r['stdout']) > n_lines:
-                        print(''.join(r['stdout'][n_lines:]), end='')
-                        n_lines = len(r['stdout'])
-                    if len(r['stderr']) > n_lines_stderr:
-                        print(''.join(r['stderr'][n_lines_stderr:]), end='')
-                        n_lines_stderr = len(r['stderr'])
-                    time.sleep(0.2)
-                else:
-                    time.sleep(0.2)
+        status = 'pending'
+        n_lines = 0
+        n_lines_stderr = 0
+        while status in {'pending', 'running'}:
             r = self.get_job(identifier)
-            if status == 'success':
+            status = r['status']
+            if status == 'running':
                 if len(r['stdout']) > n_lines:
                     print(''.join(r['stdout'][n_lines:]), end='')
+                    n_lines = len(r['stdout'])
                 if len(r['stderr']) > n_lines_stderr:
                     print(''.join(r['stderr'][n_lines_stderr:]), end='')
-            elif status == 'failed':  # pragma: no cover
-                print(r['msg'])
-        except KeyboardInterrupt:  # pragma: no cover
-            return
+                    n_lines_stderr = len(r['stderr'])
+            time.sleep(0.01)
+        r = self.get_job(identifier)
+        if status == 'success':
+            if len(r['stdout']) > n_lines:
+                print(''.join(r['stdout'][n_lines:]), end='')
+            if len(r['stderr']) > n_lines_stderr:
+                print(''.join(r['stderr'][n_lines_stderr:]), end='')
+        elif status == 'failed':  # pragma: no cover
+            print(r['msg'])
 
     @abstractmethod
     def show_jobs(self):

--- a/superduperdb/server/server.py
+++ b/superduperdb/server/server.py
@@ -257,17 +257,18 @@ def make_endpoints(app, db):
         return jsonify(response), 500
 
 
-def serve(db):
+def make_flask_app(db):
     app = Flask(__name__)
     make_endpoints(app, db)
     return app
 
 
-def main():
-    db = build_datalayer()
-    app = serve(db)
+def serve(db=None):
+    if db is None:
+        db = build_datalayer()
+    app = make_flask_app(db)
     app.run(CFG.server.host, CFG.server.port)
 
 
 if __name__ == '__main__':
-    main()
+    serve()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,7 +16,7 @@ LOCK = Lock()
 SLEEPS = {}
 SLEEP_FILE = s.ROOT / 'test/sleep.json'
 MAX_SLEEP_TIME = float('inf')
-AUTOUSE = True
+AUTOUSE = False
 
 SDDB_USE_MONGOMOCK = 'SDDB_USE_MONGOMOCK' in os.environ
 SDDB_INSTRUMENT_TIME = 'SDDB_INSTRUMENT_TIME' in os.environ

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,47 @@
+import inspect
 import os
+import time
+from threading import Lock
 
+import fil
 import pytest
 
+import superduperdb as s
 from superduperdb.misc import superduper
 
+_sleep = time.sleep
+
+SCOPE = 'function'
+LOCK = Lock()
+SLEEPS = {}
+SLEEP_FILE = s.ROOT / 'test/sleep.json'
+MAX_SLEEP_TIME = float('inf')
+AUTOUSE = True
+
 SDDB_USE_MONGOMOCK = 'SDDB_USE_MONGOMOCK' in os.environ
+SDDB_INSTRUMENT_TIME = 'SDDB_INSTRUMENT_TIME' in os.environ
+
+
+@pytest.fixture(autouse=SDDB_INSTRUMENT_TIME, scope=SCOPE)
+def patch_sleep(monkeypatch):
+    monkeypatch.setattr(time, 'sleep', sleep)
+
+
+def sleep(t: float) -> None:
+    _write(t)
+    _sleep(min(t, MAX_SLEEP_TIME))
+
+
+def _write(t):
+    stack = inspect.stack()
+    if len(stack) <= 2:
+        return
+    module = inspect.getmodule(stack[2][0]).__file__
+    with LOCK:
+        entry = SLEEPS.setdefault(module, [0, 0])
+        entry[0] += 1
+        entry[1] += t
+        fil.write(SLEEPS, SLEEP_FILE, indent=2)
 
 
 @pytest.fixture(autouse=SDDB_USE_MONGOMOCK)

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,6 +1,5 @@
 import os
 import random
-import time
 from threading import Thread
 from unittest import mock
 
@@ -196,8 +195,8 @@ def test_server(database_with_default_encoders_and_model):
         daemon=True,
     )
     t.start()
-    time.sleep(2)
-    yield
+    with app.app_context():
+        yield
 
 
 @pytest.fixture(scope="package")

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -25,7 +25,7 @@ from superduperdb.container.vector_index import VectorIndex
 from superduperdb.db.base.build import build_datalayer
 from superduperdb.db.mongodb.query import Collection
 from superduperdb.server.dask_client import dask_client
-from superduperdb.server.server import serve
+from superduperdb.server.server import make_flask_app
 
 '''
 All pytest fixtures with _package scope_ are defined in this module.
@@ -189,7 +189,7 @@ def fake_updates(database_with_default_encoders_and_model):
 
 @pytest.fixture(scope="package")
 def test_server(database_with_default_encoders_and_model):
-    app = serve(database_with_default_encoders_and_model)
+    app = make_flask_app(database_with_default_encoders_and_model)
     t = Thread(
         target=app.run,
         kwargs={"host": CFG.server.host, "port": CFG.server.port},


### PR DESCRIPTION
This was easy but it only knocked ten seconds off the build.

We still sleep 963 times for a total of 325.19 seconds in running all the tests!

The CPU usage on my machine averages about 30% of one core, so we are clearly spending a lot of time waiting around, and I'm not seeing disk or internet access to correspond to it.

I'm going to dig into this more.