### PR TITLE
Add pandoc to CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,12 +6,22 @@ on:
     paths:  # only run this action when the docs folder is changed
       - 'docs/**'
 
+# allow the action to write to the gh-pages branch
+permissions:
+  contents: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+
+        # required for 
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
 
       - name: Set up Python 3.10
         id: setup-python

--- a/docs/background/our_journey.md
+++ b/docs/background/our_journey.md
@@ -30,7 +30,7 @@ can be "semantically joined". This might mean, for example:
 - Training cross-modality search, for instance, aligning textual queries resulting for typed queries, 
   with product features.
 
-From this point of view, we believe that the ultimate production enviroment for AI, is a database, where 
+From this point of view, we believe that the ultimate production environment for AI, is a database, where 
 all documents/ rows are game to be fed through AI models, and the outputs may be saved in the database, 
 to be used downstream as inputs to further AI models, and for use in vector-search, and further approaches
 to navigating data with AI models. This is an extension of the now-standard vector-database paradigm, 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

**Note:** Please make sure that in the 'Settings->Pages' tab in our repo, that the 'Build and deployment -> Source' dropdown is set to GitHub Actions.

We require `pandoc` to build our docs. This PR (hopefully :crossed_fingers:) fixes all the issues with our docs build by adding this dependency.

I have tested this on my fork, and everything seemed to work okay. I needed to add the `write` permission to the action as the default `GITHUB_TOKEN` did not have this scope in my fork. I'm not sure if we need it, and am happy to remove it if we don't.

 ## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
