### PR TITLE
Fix missing predict kwarg

### DIFF
--- a/superduperdb/container/model.py
+++ b/superduperdb/container/model.py
@@ -322,7 +322,8 @@ class PredictMixin:
 
         if listen:
             assert db is not None
-            return self._predict_and_listen(X=X, db=db, **kwargs)
+            assert select is not None
+            return self._predict_and_listen(X=X, db=db, select=select, **kwargs)
 
         if distributed:
             return self.create_predict_job(

--- a/test/unittest/component/test_model.py
+++ b/test/unittest/component/test_model.py
@@ -31,4 +31,5 @@ def test_predict(random_data, float_tensors_32):
         db=random_data,
         select=Collection(name='documents').find(),
         distributed=False,
+        listen=True,
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This PR adds a missing kwarg to the `predict` method in the `PredictMixin` class. It also includes a very primitive form of testing. (This testing does catch the original error.)

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
