### PR TITLE
Improve performance of tests

### DIFF
--- a/.github/ci-pinned-requirements/core.txt
+++ b/.github/ci-pinned-requirements/core.txt
@@ -14,15 +14,19 @@ annotated-types==0.5.0
     # via pydantic
 async-timeout==4.0.3
     # via aiohttp
+atpublic==3.1.2
+    # via ibis-framework
 attr==0.3.2
     # via lancedb
 attrs==23.1.0
     # via aiohttp
+bidict==0.22.1
+    # via ibis-framework
 blinker==1.6.2
     # via flask
-boto3==1.28.40
+boto3==1.28.42
     # via superduperdb (pyproject.toml)
-botocore==1.31.40
+botocore==1.31.42
     # via
     #   boto3
     #   s3transfer
@@ -54,6 +58,12 @@ distributed==2023.5.0
     # via dask
 dnspython==2.4.2
     # via pymongo
+duckdb==0.8.1
+    # via
+    #   duckdb-engine
+    #   ibis-framework
+duckdb-engine==0.9.2
+    # via ibis-framework
 fil==1.3.0
     # via superduperdb (pyproject.toml)
 flask==2.3.3
@@ -71,6 +81,8 @@ frozenlist==1.4.0
     #   aiosignal
 fsspec==2023.9.0
     # via dask
+ibis-framework[duckdb,sqlite]==5.1.0
+    # via superduperdb (pyproject.toml)
 idna==3.4
     # via
     #   requests
@@ -79,6 +91,8 @@ importlib-metadata==6.8.0
     # via
     #   dask
     #   flask
+importlib-resources==5.13.0
+    # via ibis-framework
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
@@ -97,20 +111,27 @@ locket==1.0.0
     # via
     #   distributed
     #   partd
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
+mdurl==0.1.2
+    # via markdown-it-py
 msgpack==1.0.5
     # via distributed
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
+multipledispatch==0.6.0
+    # via ibis-framework
 networkx==3.1
     # via superduperdb (pyproject.toml)
 numpy==1.24.4
     # via
+    #   ibis-framework
     #   pandas
     #   pyarrow
     #   pylance
@@ -125,24 +146,38 @@ packaging==23.1
     # via
     #   dask
     #   distributed
+    #   ibis-framework
+    #   pooch
 pandas==2.0.3
-    # via superduperdb (pyproject.toml)
+    # via
+    #   ibis-framework
+    #   superduperdb (pyproject.toml)
+parsy==2.1
+    # via ibis-framework
 partd==1.4.0
     # via dask
 pillow==10.0.0
     # via superduperdb (pyproject.toml)
+platformdirs==3.10.0
+    # via pooch
+pooch[progress,xxhash]==1.7.0
+    # via ibis-framework
 psutil==5.9.5
     # via distributed
 py==1.11.0
     # via retry
-pyarrow==13.0.0
-    # via pylance
+pyarrow==11.0.0
+    # via
+    #   ibis-framework
+    #   pylance
 pydantic==2.3.0
     # via
     #   lancedb
     #   superduperdb (pyproject.toml)
 pydantic-core==2.6.3
     # via pydantic
+pygments==2.16.1
+    # via rich
 pylance==0.5.10
     # via lancedb
 pymongo==4.5.0
@@ -150,9 +185,12 @@ pymongo==4.5.0
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   ibis-framework
     #   pandas
-pytz==2023.3
-    # via pandas
+pytz==2023.3.post1
+    # via
+    #   ibis-framework
+    #   pandas
 pyyaml==6.0.1
     # via
     #   dask
@@ -161,12 +199,17 @@ ratelimiter==1.2.0.post0
     # via lancedb
 readerwriterlock==1.0.9
     # via superduperdb (pyproject.toml)
+regex==2023.8.8
+    # via ibis-framework
 requests==2.31.0
     # via
     #   openai
+    #   pooch
     #   superduperdb (pyproject.toml)
 retry==0.9.2
     # via lancedb
+rich==13.5.2
+    # via ibis-framework
 s3transfer==0.6.2
     # via boto3
 safer==4.8.0
@@ -182,9 +225,20 @@ semver==3.0.1
     #   lancedb
     #   superduperdb (pyproject.toml)
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   multipledispatch
+    #   python-dateutil
 sortedcontainers==2.4.0
     # via distributed
+sqlalchemy==2.0.20
+    # via
+    #   duckdb-engine
+    #   ibis-framework
+    #   sqlalchemy-views
+sqlalchemy-views==0.3.2
+    # via ibis-framework
+sqlglot==11.7.1
+    # via ibis-framework
 tblib==2.0.0
     # via distributed
 tenacity==8.2.3
@@ -195,6 +249,7 @@ toolz==0.12.0
     # via
     #   dask
     #   distributed
+    #   ibis-framework
     #   partd
 tornado==6.3.3
     # via distributed
@@ -202,15 +257,19 @@ tqdm==4.66.1
     # via
     #   lancedb
     #   openai
+    #   pooch
     #   superduperdb (pyproject.toml)
 typer==0.9.0
     # via superduperdb (pyproject.toml)
 typing-extensions==4.7.1
     # via
     #   annotated-types
+    #   ibis-framework
     #   pydantic
     #   pydantic-core
     #   readerwriterlock
+    #   rich
+    #   sqlalchemy
     #   typer
 tzdata==2023.3
     # via pandas
@@ -223,9 +282,13 @@ werkzeug==2.3.7
     # via
     #   flask
     #   superduperdb (pyproject.toml)
+xxhash==3.3.0
+    # via pooch
 yarl==1.9.2
     # via aiohttp
 zict==3.0.0
     # via distributed
 zipp==3.16.2
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/.github/ci-pinned-requirements/dev.txt
+++ b/.github/ci-pinned-requirements/dev.txt
@@ -18,7 +18,9 @@ annotated-types==0.5.0
     # via pydantic
 anyio==4.0.0
     # via httpcore
-asttokens==2.3.0
+appnope==0.1.3
+    # via ipython
+asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3
     # via aiohttp
@@ -50,17 +52,17 @@ bleach==6.0.0
     # via nbconvert
 blinker==1.6.2
     # via flask
-boto3==1.28.40
+boto3==1.28.42
     # via
     #   superduperdb
     #   superduperdb (pyproject.toml)
-boto3-stubs==1.28.40
+boto3-stubs==1.28.42
     # via superduperdb
-botocore==1.31.40
+botocore==1.31.42
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.40
+botocore-stubs==1.31.42
     # via boto3-stubs
 certifi==2023.7.22
     # via
@@ -83,11 +85,9 @@ cloudpickle==2.2.1
     # via
     #   dask
     #   distributed
-cmake==3.27.2
-    # via triton
 colorama==0.4.6
     # via interrogate
-coverage[toml]==7.3.0
+coverage[toml]==7.3.1
     # via pytest-cov
 dask[distributed]==2023.5.0
     # via
@@ -127,6 +127,8 @@ exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
+execnet==2.0.2
+    # via pytest-xdist
 executing==1.2.0
     # via stack-data
 fastjsonschema==2.18.0
@@ -140,7 +142,6 @@ filelock==3.12.3
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 flask==2.3.3
     # via
     #   flask-cors
@@ -165,8 +166,6 @@ fsspec==2023.9.0
     #   huggingface-hub
 furo==2023.8.19
     # via superduperdb
-greenlet==2.0.2
-    # via sqlalchemy
 h11==0.14.0
     # via httpcore
 httpcore==0.17.3
@@ -250,8 +249,6 @@ lancedb==0.1.16
     #   superduperdb (pyproject.toml)
 libcst==1.0.1
     # via monkeytype
-lit==16.0.6
-    # via triton
 locket==1.0.0
     # via
     #   distributed
@@ -333,31 +330,6 @@ numpy==1.24.4
     #   superduperdb (pyproject.toml)
     #   torchvision
     #   transformers
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 openai==0.28.0
     # via
     #   superduperdb
@@ -461,8 +433,11 @@ pymongo==4.5.0
 pytest==7.4.1
     # via
     #   pytest-cov
+    #   pytest-xdist
     #   superduperdb
 pytest-cov==4.1.0
+    # via superduperdb
+pytest-xdist==3.3.1
     # via superduperdb
 python-dateutil==2.8.2
     # via
@@ -470,7 +445,7 @@ python-dateutil==2.8.2
     #   ibis-framework
     #   jupyter-client
     #   pandas
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   babel
     #   ibis-framework
@@ -600,7 +575,6 @@ sqlglot==11.7.1
     # via ibis-framework
 stack-data==0.6.2
     # via ipython
-superduperdb[docs,lint,tests,torch,typing]
     # via superduperdb (pyproject.toml)
 sympy==1.12
     # via torch
@@ -639,7 +613,6 @@ torch==2.0.0
     #   accelerate
     #   superduperdb
     #   torchvision
-    #   triton
 torchvision==0.15.1
     # via superduperdb
 tornado==6.3.3
@@ -665,17 +638,15 @@ traitlets==5.9.0
     #   nbconvert
     #   nbformat
     #   nbsphinx
-transformers==4.32.1
+transformers==4.33.1
     # via superduperdb
-triton==2.0.0
-    # via torch
 typer==0.9.0
     # via
     #   superduperdb
     #   superduperdb (pyproject.toml)
 types-awscrt==0.19.1
     # via botocore-stubs
-types-pillow==10.0.0.2
+types-pillow==10.0.0.3
     # via superduperdb
 types-requests==2.31.0.2
     # via superduperdb
@@ -725,14 +696,6 @@ werkzeug==2.3.7
     #   flask
     #   superduperdb
     #   superduperdb (pyproject.toml)
-wheel==0.41.2
-    # via
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
 xmod==1.5.0
     # via
     #   dek
@@ -747,6 +710,3 @@ zipp==3.16.2
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/.github/ci-pinned-requirements/docs.txt
+++ b/.github/ci-pinned-requirements/docs.txt
@@ -14,7 +14,9 @@ alabaster==0.7.13
     # via sphinx
 annotated-types==0.5.0
     # via pydantic
-asttokens==2.3.0
+appnope==0.1.3
+    # via ipython
+asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3
     # via aiohttp
@@ -41,9 +43,9 @@ bleach==6.0.0
     # via nbconvert
 blinker==1.6.2
     # via flask
-boto3==1.28.40
+boto3==1.28.42
     # via superduperdb (pyproject.toml)
-botocore==1.31.40
+botocore==1.31.42
     # via
     #   boto3
     #   s3transfer
@@ -113,8 +115,6 @@ fsspec==2023.9.0
     # via dask
 furo==2023.8.19
     # via superduperdb (pyproject.toml)
-greenlet==2.0.2
-    # via sqlalchemy
 ibis-framework[duckdb,sqlite]==5.1.0
     # via superduperdb (pyproject.toml)
 idna==3.4
@@ -310,7 +310,7 @@ python-dateutil==2.8.2
     #   ibis-framework
     #   jupyter-client
     #   pandas
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   babel
     #   ibis-framework

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ tests = [
     "lorem>=0.1.1",
     "pytest>=7.3.1",
     "pytest-cov>=2.12.1",
+    "pytest-xdist>=3.3.1",
     "tdir>=1.6"
 ]
 dev = ["superduperdb[docs,lint,tests,typing,torch]"]

--- a/superduperdb/db/mongodb/cdc.py
+++ b/superduperdb/db/mongodb/cdc.py
@@ -215,7 +215,7 @@ class CDCHandler(threading.Thread):
     """
 
     _QUEUE_BATCH_SIZE: int = 100
-    _QUEUE_TIMEOUT: int = 2
+    _QUEUE_TIMEOUT: float = 0.01
 
     def __init__(self, db: DB, stop_event: threading.Event):
         """__init__.

--- a/superduperdb/server/client.py
+++ b/superduperdb/server/client.py
@@ -39,12 +39,13 @@ class ClientArtifactStore:
 
 
 class Client:
-    def __init__(self, uri):
+    def __init__(self, uri, requests=requests):
         """
         :param uri: uri of the server
         """
         self.uri = uri
         self.encoders = LoadDict(self, 'encoder')
+        self.requests = requests
 
     def execute(self, query: ExecuteQuery):
         if isinstance(query, Delete):
@@ -399,10 +400,11 @@ class Client:
         params: t.Optional[t.Dict] = None,
         json: t.Optional[t.Dict] = None,
     ):
-        response = requests.get(f'{self.uri}/{route}', params=params, json=json)
+        response = self.requests.get(f'{self.uri}/{route}', params=params, json=json)
+        print('YYYYY', response)
         if response.status_code != 200:
             raise ServerSideException(
-                f'Non 200 status while making request to'
+                f'HTTP status {response.status_code} while making request to'
                 f' /{route} with params {params} and json {json}:\n'
                 f'{response.text}'
             )
@@ -417,7 +419,7 @@ class Client:
     ):
         if method not in ['PUT', 'POST']:
             raise ServerSideException('Only PUT or POST methods are supported')
-        fn = getattr(requests, method.lower())
+        fn = getattr(self.requests, method.lower())
         response = fn(
             f'{self.uri}/{route}',
             data=data,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,7 +19,6 @@ LOCK = Lock()
 SLEEPS = {}
 SLEEP_FILE = s.ROOT / 'test/sleep.json'
 MAX_SLEEP_TIME = float('inf')
-AUTOUSE = False
 
 SDDB_USE_MONGOMOCK = 'SDDB_USE_MONGOMOCK' in os.environ
 SDDB_INSTRUMENT_TIME = 'SDDB_INSTRUMENT_TIME' in os.environ

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,6 +1,5 @@
 import os
 import random
-from threading import Thread
 
 import numpy as np
 import pytest
@@ -19,7 +18,6 @@ from superduperdb.container.listener import Listener
 from superduperdb.container.vector_index import VectorIndex
 from superduperdb.db.mongodb.query import Collection
 from superduperdb.server.dask_client import dask_client
-from superduperdb.server.server import make_flask_app
 
 '''
 All pytest fixtures with _package scope_ are defined in this module.
@@ -110,19 +108,6 @@ def fake_inserts(database_with_default_encoders_and_model):
 def fake_updates(database_with_default_encoders_and_model):
     encoder = database_with_default_encoders_and_model.encoders['torch.float32[32]']
     return fake_tensor_data(encoder, update=True)
-
-
-@pytest.fixture
-def test_server(database_with_default_encoders_and_model):
-    app = make_flask_app(database_with_default_encoders_and_model)
-    t = Thread(
-        target=app.run,
-        kwargs={"host": CFG.server.host, "port": CFG.server.port},
-        daemon=True,
-    )
-    t.start()
-    with app.app_context():
-        yield
 
 
 @pytest.fixture

--- a/test/integration/test_cdc.py
+++ b/test/integration/test_cdc.py
@@ -44,7 +44,6 @@ def listener_and_collection_name(database_with_default_encoders_and_model):
     listener = DatabaseListener(
         db=database_with_default_encoders_and_model, on=Collection(name=collection_name)
     )
-    listener._cdc_change_handler._QUEUE_TIMEOUT = 1
     listener._cdc_change_handler._QUEUE_BATCH_SIZE = 1
 
     yield listener, collection_name

--- a/test/integration/test_notebooks.py
+++ b/test/integration/test_notebooks.py
@@ -6,7 +6,7 @@ import tempfile
 import pytest
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def copy_superduperdb():
     with tempfile.TemporaryDirectory() as tmp_dir:
         shutil.copytree('superduperdb', os.path.join(tmp_dir, 'superduperdb'))

--- a/test/integration/test_notebooks.py
+++ b/test/integration/test_notebooks.py
@@ -1,16 +1,12 @@
 import os
-import shutil
 import subprocess
-import tempfile
 
 import pytest
+import tdir
 
+import superduperdb as s
 
-@pytest.fixture
-def copy_superduperdb():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        shutil.copytree('superduperdb', os.path.join(tmp_dir, 'superduperdb'))
-        yield tmp_dir
+ENABLE = 'NB_TEST' in os.environ
 
 
 def run_python_file(file_path, tmp_dir):
@@ -37,9 +33,8 @@ NOTEBOOKS = [
 ]
 
 
-@pytest.mark.skipif(
-    os.environ.get('NB_TEST', 0) == 0, reason="Notebook tests are disabled"
-)
-@pytest.mark.parametrize("nb_file", NOTEBOOKS)
-def test_notebooks(nb_file, copy_superduperdb):
-    run_python_file(nb_file, tmp_dir=copy_superduperdb)
+@pytest.mark.skipif(not ENABLE, reason='Notebook tests are disabled')
+@pytest.mark.parametrize('nb_file', NOTEBOOKS)
+@tdir(superduperdb=s.ROOT / 'superduperdb')
+def test_notebooks(nb_file):
+    run_python_file(nb_file, tmp_dir='.')

--- a/test/integration/test_server.py
+++ b/test/integration/test_server.py
@@ -48,8 +48,7 @@ def client(database_with_default_encoders_and_model):
     yield Client(CFG.server.uri, TestRequest(app.test_client()))
 
 
-# scope="function" so that each test gets a new collection
-@pytest.fixture(scope="function")
+@pytest.fixture
 def test_collection():
     collection_name = str(uuid.uuid4())
     return Collection(name=collection_name)

--- a/test/unittest/component/test_documents.py
+++ b/test/unittest/component/test_documents.py
@@ -10,7 +10,7 @@ except ImportError:
 from superduperdb.container.document import Document
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def document():
     t = tensor(torch.float, shape=(20,))
 

--- a/test/unittest/db/base/test_downloaders.py
+++ b/test/unittest/db/base/test_downloaders.py
@@ -1,7 +1,8 @@
 import os
-import shutil
+from test.unittest.db.mongodb.test_database import IMAGE_URL
 
 import pytest
+import tdir
 
 from superduperdb import CFG
 from superduperdb.container.document import Document
@@ -9,10 +10,7 @@ from superduperdb.db.base.download import Fetcher
 from superduperdb.db.mongodb.query import Collection
 from superduperdb.ext.pillow.image import pil_image
 
-remote = os.environ.get('SUPERDUPERDB_REMOTE_TEST', 'local')
-
-
-IMAGE_URL = 'https://www.superduperdb.com/logos/white.png'
+remote = os.environ.get('SDDB_REMOTE_TEST', 'local')
 
 
 def test_s3_and_web():
@@ -21,19 +19,14 @@ def test_s3_and_web():
 
 
 @pytest.fixture
-def make_hybrid_cfg():
-    old = CFG.downloads.hybrid
-    CFG.downloads.hybrid = True
-    root_old = CFG.downloads.root
-    CFG.downloads.root = '.tdir_hybrid'
-    os.makedirs('.tdir_hybrid', exist_ok=True)
-    yield CFG
-    CFG.downloads.hybrid = old
-    CFG.downloads.root = root_old
-    shutil.rmtree('.tdir_hybrid')
+def patch_cfg_downloads(monkeypatch):
+    with tdir() as td:
+        monkeypatch.setattr(CFG.downloads, 'hybrid', True)
+        monkeypatch.setattr(CFG.downloads, 'root', td)
+        yield
 
 
-def test_file_blobs(empty, make_hybrid_cfg):
+def test_file_blobs(empty, patch_cfg_downloads):
     to_insert = [
         Document(
             {
@@ -58,6 +51,4 @@ def test_file_blobs(empty, make_hybrid_cfg):
 
     empty.execute(Collection('documents').insert_many(to_insert, encoders=(pil_image,)))
     empty.execute(Collection('documents').find_one())
-    imgs = os.listdir('.tdir_hybrid/')
-
-    assert imgs
+    assert list(CFG.downloads.root.iterdir())

--- a/test/unittest/model/test_transformers.py
+++ b/test/unittest/model/test_transformers.py
@@ -15,7 +15,7 @@ from superduperdb.ext.transformers.model import (
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def transformers_model(random_data):
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 

--- a/test/unittest/vector_search/test_lancedb.py
+++ b/test/unittest/vector_search/test_lancedb.py
@@ -17,7 +17,7 @@ from superduperdb.vector_search.lancedb_client import (
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def lance_client():
     with tempfile.TemporaryDirectory() as tmpdirname:
         client = LanceDBClient(uri=f'./{tmpdirname}/.test_db')
@@ -27,13 +27,13 @@ def lance_client():
         yield client, table
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def lance_table(lance_client):
     lance_client, table = lance_client
     yield table
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def lance_vector_index(lance_client):
     lance_client, table = lance_client
     vector_index = LanceVectorIndex(uri='./.lancedb', client=lance_client)


### PR DESCRIPTION
Nothing here is a huge win but they are improvements.

All fixtures are now function-scope.  Some tests clean up better on error, or fail rather than hanging indefinitely on errors, and don't put files into the source directory.

We are much closer to our target of being able to run everything in parallel with mongomock:

```
$ SDDB_USE_MONGOMOCK= time pytest -n auto

FAILED test/integration/test_server.py::test_remove - AssertionError: assert ['torch.float....float64[32]'] == [...
FAILED test/integration/test_server.py::test_show - AssertionError: assert ['torch.float....float32[16]'] == ['t...
FAILED test/unittest/db/mongodb/test_query_dataset.py::test_query_dataset - IndexError: list index out of range
FAILED test/integration/test_cdc.py::test_delete_one - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_task_workflow[insert] - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_vector_database_sync - ValueError: state_check() never succeeded
FAILED test/unittest/db/mongodb/test_query_dataset.py::test_query_dataset_base - IndexError: list index out of r...
FAILED test/integration/test_dask.py::test_insert_with_dask - KeyError: '_outputs'
FAILED test/integration/test_cdc.py::test_single_update - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_single_insert - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_task_workflow[update] - ValueError: state_check() never succeeded
FAILED test/integration/test_dask.py::test_taskgraph_futures_with_dask - assert False
FAILED test/integration/test_cdc.py::test_many_update - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_many_insert - ValueError: state_check() never succeeded
FAILED test/integration/test_cdc.py::test_vector_database_sync_with_delete - ValueError: state_check() never suc...
=================================== 15 failed, 120 passed, 5 skipped in 25.89s ====================================
       27.07 real        66.29 user        24.58 sys
```

Without parallelism, the tests take 78 seconds, and I think we can do even better, if we get it working.

@blythed, I made some changes to test_notebooks.py but I can't get them to work before or after on my machine, your guidance is solicited.

