### PR TITLE
Fix dev.txt requirement after updating

### DIFF
--- a/.github/ci-pinned-requirements/update-pinned-deps.sh
+++ b/.github/ci-pinned-requirements/update-pinned-deps.sh
@@ -22,3 +22,5 @@ do
     --upgrade \
     pyproject.toml
 done
+
+sed -I '' '/superduperdb\[/d' .github/ci-pinned-requirements/dev.txt


### PR DESCRIPTION
Hacky fix for the update-pinned-deps.sh issue.

The matching string is fairly general while only matching the one line.

It does leave an orphaned comment behind but no one will ever notice that. :-)