### PR TITLE
Force Python 3.8 in update-pinned-deps (fix #874)

### DIFF
--- a/.github/ci-pinned-requirements/update-pinned-deps.sh
+++ b/.github/ci-pinned-requirements/update-pinned-deps.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-set -e  # Stop execution if any command fails
+set -eu
+
+if [[ "$(python --version)" != "Python 3.8"* ]] ; then
+    echo 'This script must be run under Python 3.8'
+    exit 1
+fi
 
 python -m pip install --upgrade pip-tools pip
 


### PR DESCRIPTION
One tiny tiny comment: I removed the comment on line 3, and tweaked it, on the theory "Don't explain what an average practitioner would either know or look up."

I generally use `set -euxo pipefail` https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425 but it produces a lot of blah blah.  But `-u` should be standard... :-)