### PR TITLE
Fix doc comments for dataclasses (fix #879)

### DIFF
--- a/superduperdb/base/config.py
+++ b/superduperdb/base/config.py
@@ -11,51 +11,49 @@ from .jsonable import Factory, JSONable
 
 
 class Retry(JSONable):
-    """
-    Describes how to retry using the `tenacity` library
+    """Describes how to retry using the `tenacity` library"""
 
-    :param stop_after_attempt: The number of attempts to make
-    :param wait_max: The maximum time to wait between attempts
-    :param wait_min: The minimum time to wait between attempts
-    :param wait_multiplier: The multiplier for the wait time between attempts
-    """
-
+    #: The number of attempts to make
     stop_after_attempt: int = 2
+
+    #: The maximum time to wait between attempts
     wait_max: float = 10.0
+
+    #: The minimum time to wait between attempts
     wait_min: float = 4.0
+
+    #: The multiplier for the wait time between attempts
     wait_multiplier: float = 1.0
 
 
 class Apis(JSONable):
-    """
-    A container for API connections
+    """A container for API connections"""
 
-    :param providers: A dictionary of API connections
-    :param retry: A ``Retry`` object
-    """
-
+    #: A ``Retry`` object
     retry: Retry = Factory(Retry)
 
 
 class Cluster(JSONable):
-    """
-    Describes a connection to distributed work via Dask
+    """Describes a connection to distributed work via Dask"""
 
-    :param distributed: Whether to use distributed task
-                        management via Dask or not
-    :param deserializers: A list of deserializers
-    :param serializers: A list of serializers
-    :param dask_scheduler: The Dask scheduler URI
-    :param local: Whether the connection is local
-    :param cdc: Whether change data capture should be used
-    """
-
+    #: Whether to use distributed task management via Dask or not
     distributed: bool = False
+
+    #: A list of deserializers
     deserializers: t.List[str] = Factory(list)
+
+    #: A list of serializers
     serializers: t.List[str] = Factory(list)
+
+    #: The Dask scheduler URI
     dask_scheduler: str = 'tcp://localhost:8786'
+
+    #: Whether the connection is local
     local: bool = True
+
+    #: Whether change data capture should be used
     cdc: bool = False
+
     backfill_batch_size: int = 100
 
 
@@ -75,30 +73,28 @@ class LogType(str, Enum):
 
 
 class Logging(JSONable):
-    """
-    Describe how we are going to log. This isn't yet used.
+    """Describe how we are going to log. This isn't yet used."""
 
-    :param level: The log level
-    :param type: The log type
-    :param kwargs: Any additional keyword arguments
-    """
-
+    #: The log level
     level: LogLevel = LogLevel.INFO
+
+    #: The log type
     type: LogType = LogType.STDERR
+
+    #: Any additional keyword arguments
     kwargs: dict = Factory(dict)
 
 
 class Server(JSONable):
-    """
-    Configure the SuperDuperDB server connection information
+    """Configure the SuperDuperDB server connection information"""
 
-    :param host: The host for the connection
-    :param port: The port for the connection
-    :param protocol: The protocol for the connection
-    """
-
+    #: The host for the connection
     host: str = '127.0.0.1'
+
+    #: The port for the connection
     port: int = 3223
+
+    #: The protocol for the connection
     protocol: str = 'http'
 
     @property
@@ -110,51 +106,44 @@ class Downloads(JSONable):
     """
     Configure how downloads are saved in the database
     or to hybrid filestorage (references to filesystem from datastore)
-
-    :param hybrid: Whether hybrid is being used
-    :param root: The root for the connection
     """
 
+    #: Whether hybrid is being used
     hybrid: bool = False
+
+    #: The root for the connection
     root: str = 'data/downloads'
 
 
 class Config(JSONable):
-    """
-    The data class containing all configurable superduperdb values
-
-    :param data_backend: The URI for the data backend
-    :param vector_search: The URI for the vector search
-    :param artifact_store: The URI for the artifact store
-    :param metadata_store: The URI for the metadata store
-
-    :param apis: The ``Apis`` object
-    :param cluster: The ``Cluster`` object
-    :param logging: The ``Logging`` object
-    :param server: The ``Server`` object
-    :param downloads: The ``Downloads`` object
-    """
+    """The data class containing all configurable superduperdb values"""
 
     # 4 main components are URI strings
+    #: The URI for the data backend
     data_backend: str = 'mongodb://localhost:27017'
+
+    #: The URI for the vector search
     vector_search: 'str' = 'inmemory://'  # 'lancedb://./.lancedb'
+
+    #: The URI for the artifact store
     artifact_store: t.Optional[str] = None
+
+    #: The URI for the metadata store
     metadata_store: t.Optional[str] = None
 
-    # main settings for all things related to distributed computing
-    # and change data capture in Cluster
+    #: Settings distributed computing and change data capture
     cluster: Cluster = Factory(Cluster)
 
-    # settings for OPENAI etc.
+    #: Settings for OPENAI and other APIs
     apis: Apis = Factory(Apis)
 
-    # logging - nuff said
+    #: Logging
     logging: Logging = Factory(Logging)
 
-    # experimental server
+    #: Settings for the experimental Rest server
     server: Server = Factory(Server)
 
-    # settings for downloads
+    #: Settings for downloading files
     downloads: Downloads = Factory(Downloads)
 
     class Config(JSONable.Config):

--- a/superduperdb/base/configs.py
+++ b/superduperdb/base/configs.py
@@ -35,16 +35,18 @@ FILE_SEP = ','
 class ConfigSettings:
     """
     A class that reads a Pydantic class from config files and environment variables.
-
-    :param cls: The Pydantic class to read.
-    :param default_files: The default config files to read.
-    :param prefix: The prefix to use for environment variables.
-    :param environ: The environment variables to read from.
     """
 
+    #: The Pydantic class to read.
     cls: t.Type
+
+    #: The default config files to read.
     default_files: t.Union[t.Sequence[Path], str]
+
+    #: The prefix to use for environment variables.
     prefix: str
+
+    #: The environment variables to read from.
     environ: t.Optional[t.Dict] = None
 
     @cached_property

--- a/superduperdb/container/dataset.py
+++ b/superduperdb/container/dataset.py
@@ -18,24 +18,27 @@ if t.TYPE_CHECKING:
 
 @dc.dataclass
 class Dataset(Component):
-    """
-    A dataset is an immutable collection of documents that can be used for training
+    """A dataset is an immutable collection of documents that used for training"""
 
-    :param identifier: A unique identifier for the dataset
-    :param select: A query to select the documents for the dataset
-    :param sample_size: The number of documents to sample from the query
-    :param random_seed: The random seed to use for sampling
-    :param creation_date: The date the dataset was created
-    :param raw_data: The raw data for the dataset
-    :param version: The version of the dataset
-    """
-
+    #: A unique identifier for the dataset
     identifier: str
+
+    #: A query to select the documents for the dataset
     select: t.Optional[Find] = None
+
+    #: The number of documents to sample from the query
     sample_size: t.Optional[int] = None
+
+    #: The random seed to use for sampling
     random_seed: t.Optional[int] = None
+
+    #: The date the dataset was created
     creation_date: t.Optional[str] = None
+
+    #: The raw data for the dataset
     raw_data: t.Optional[t.Union[Artifact, t.Any]] = None
+
+    #: The version of the dataset
     version: t.Optional[int] = None
 
     #: A unique name for the class

--- a/superduperdb/container/encoder.py
+++ b/superduperdb/container/encoder.py
@@ -1,4 +1,3 @@
-import dataclasses
 import dataclasses as dc
 import io
 import pickle
@@ -21,26 +20,24 @@ def _pickle_encoder(x: t.Any) -> bytes:
     return f.getvalue()
 
 
-@dataclasses.dataclass
+@dc.dataclass
 class Encoder(Component):
     """
     Storeable ``Component`` allowing byte encoding of primary data,
     i.e. data inserted using ``db.base.db.Datalayer.insert``
-
-    :param identifier: unique identifier
-    :param encoder: callable converting an ``Encodable`` of this ``Encoder`` to
-                    be converted to ``bytes``
-    :param decoder: callable converting a ``bytes`` string to a ``Encodable`` of
-                    this ``Encoder``
-    :param shape: shape of the data, if any
     """
 
     artifacts: t.ClassVar[t.Sequence[str]] = ['decoder', 'encoder']
 
+    #: Unique identifier
     identifier: str
+
+    #: callable converting a ``bytes`` string to a ``Encodable`` of this ``Encoder``
     decoder: t.Union[t.Callable, Artifact] = dc.field(
         default_factory=lambda: Artifact(artifact=_pickle_decoder)
     )
+
+    #: Callable converting an ``Encodable`` of this ``Encoder`` to ``bytes``
     encoder: t.Union[t.Callable, Artifact] = dc.field(
         default_factory=lambda: Artifact(artifact=_pickle_encoder)
     )
@@ -110,14 +107,15 @@ class Encodable:
     """
     Data variable wrapping encode-able item. Encoding is controlled by the referred
     to ``Encoder`` instance.
-
-    :param encoder: Instance of ``Encoder`` controlling encoding
-    :param x: Wrapped content
-    :param uri: URI of the content, if any
     """
 
+    #: Instance of ``Encoder`` controlling encoding
     encoder: t.Callable
+
+    #: Wrapped content
     x: t.Optional[t.Any] = None
+
+    #: URI of the content, if any
     uri: t.Optional[str] = None
 
     def encode(self) -> t.Dict[str, t.Any]:

--- a/superduperdb/container/listener.py
+++ b/superduperdb/container/listener.py
@@ -16,26 +16,30 @@ class Listener(Component):
     """
     Listener object which is used to process a column/ key of a collection or table,
     and store the outputs.
-
-    :param key: Key to be bound to model
-    :param model: Model for processing data
-    :param select: Object for selecting which data is processed
-
-    :param active: Toggle to ``False`` to deactivate change data triggering
-    :param features: Dictionary of mappings from keys to model
-    :param identifier: A string used to identify the model.
-    :param predict_kwargs: Keyword arguments to self.model.predict
-    :param version: Version number of the model(?)
     """
 
+    #: Key to be bound to model
     key: str
+
+    #: Model for processing data
     model: t.Union[str, Model]
+
+    #: Object for selecting which data is processed
     select: Select
 
+    #: Toggle to ``False`` to deactivate change data triggering
     active: bool = True
+
+    #: Dictionary of mappings from keys to model
     features: t.Optional[t.Dict] = None
+
+    #: A string used to identify the model.
     identifier: t.Optional[str] = None
+
+    #: Keyword arguments to self.model.predict
     predict_kwargs: t.Optional[t.Dict] = dc.field(default_factory=dict)
+
+    #: Version number of the model(?)
     version: t.Optional[int] = None
 
     #: A unique name for the class

--- a/superduperdb/container/metric.py
+++ b/superduperdb/container/metric.py
@@ -10,16 +10,17 @@ class Metric(Component):
     """
     Metric base object with which to evaluate performance on a data-set.
     These objects are ``callable`` and are applied row-wise to the data, and averaged.
-
-    :param identifier: unique identifier
-    :param object: callable or ``Artifact`` to be applied to the data
-    :param version: version of the ``Metric``
     """
 
     artifacts: t.ClassVar[t.List[str]] = ['object']
 
+    #: unique identifier
     identifier: str
+
+    #: callable or ``Artifact`` to be applied to the data
     object: t.Union[Artifact, t.Callable, None] = None
+
+    #: version of the ``Metric``
     version: t.Optional[int] = None
 
     #: A unique name for the class

--- a/superduperdb/container/model.py
+++ b/superduperdb/container/model.py
@@ -43,12 +43,12 @@ class _TrainingConfiguration(Component):
     :param version: Version number of the configuration
     """
 
-    #: A unique name for the class
-    type_id: t.ClassVar[str] = 'training_configuration'
-
     identifier: str
     kwargs: t.Optional[t.Dict] = None
     version: t.Optional[int] = None
+
+    #: A unique name for the class
+    type_id: t.ClassVar[str] = 'training_configuration'
 
     def get(self, k, default=None):
         try:
@@ -60,24 +60,30 @@ class _TrainingConfiguration(Component):
 class PredictMixin:
     """
     Mixin class for components which can predict.
-
-    :param identifier: Unique identifier of model
-    :param encoder: Encoder instance (optional)
-    :param preprocess: Preprocess function (optional)
-    :param postprocess: Postprocess function (optional)
-    :param collate_fn: Collate function (optional)
-    :param batch_predict: Whether to batch predict (optional)
-    :param takes_context: Whether the model takes context into account (optional)
-    :param to_call: The method to use for prediction (optional)
     """
 
+    #: Unique identifier of model
     identifier: str
+
+    #: Encoder instance (optional)
     encoder: EncoderArg
+
+    #: Preprocess function (optional)
     preprocess: t.Union[t.Callable, Artifact, None] = None
+
+    #: Postprocess function (optional)
     postprocess: t.Union[t.Callable, Artifact, None] = None
+
+    #: Collate function (optional)
     collate_fn: t.Union[t.Callable, Artifact, None] = None
+
+    #: Whether to batch predict (optional)
     batch_predict: bool
+
+    #: Whether the model takes context into account (optional)
     takes_context: bool
+
+    #: The method to use for prediction (optional)
     to_call: t.Callable
 
     def create_predict_job(
@@ -365,30 +371,36 @@ class PredictMixin:
 
 @dc.dataclass
 class Model(Component, PredictMixin):
-    """
-    Model component which wraps a model to become serializable
+    """Model component which wraps a model to become serializable"""
 
-    :param identifier: Unique identifier of model
-    :param object: Model object, e.g. sklearn model, etc..
-    :param encoder: Encoder instance (optional)
-    :param preprocess: Preprocess function (optional)
-    :param postprocess: Postprocess function (optional)
-    :param collate_fn: Collate function (optional)
-    :param metrics: Metrics to use (optional)
-    :param predict_method: The method to use for prediction (optional)
-    :param batch_predict: Whether to batch predict (optional)
-    :param takes_context: Whether the model takes context into account (optional)
-    """
-
+    #: Unique identifier of model
     identifier: str
+
+    #: Model object, e.g. sklearn model, etc..
     object: t.Union[Artifact, t.Any]
+
+    #: Encoder instance (optional)
     encoder: t.Any = None
+
+    #: Preprocess function (optional)
     preprocess: t.Union[t.Callable, Artifact, None] = None
+
+    #: Postprocess function (optional)
     postprocess: t.Union[t.Callable, Artifact, None] = None
+
+    #: Collate function (optional)
     collate_fn: t.Union[t.Callable, Artifact, None] = None
+
+    #: Metrics to use (optional)
     metrics: t.Sequence[t.Union[str, Metric, None]] = ()
+
+    #: The method to use for prediction (optional)
     predict_method: t.Optional[str] = None
+
+    #: Whether to batch predict (optional)
     batch_predict: bool = False
+
+    #: Whether the model takes context into account (optional)
     takes_context: bool = False
 
     train_X: DataArg = None

--- a/superduperdb/container/task_workflow.py
+++ b/superduperdb/container/task_workflow.py
@@ -20,12 +20,12 @@ class TaskWorkflow:
     """
     Keep a graph of jobs that need to be performed and their dependencies,
     and perform them when called.
-
-    :param database: ``DB`` instance to use
-    :param G: ``networkx.DiGraph`` to use as the graph
     """
 
+    #: ``DB`` instance to use
     database: DB
+
+    #: ``networkx.DiGraph`` to use as the graph
     G: DiGraph = dc.field(default_factory=DiGraph)
 
     @wraps(DiGraph.add_edge)

--- a/superduperdb/container/vector_index.py
+++ b/superduperdb/container/vector_index.py
@@ -44,23 +44,27 @@ def ibatch(iterable: t.Iterable[T], batch_size: int) -> t.Iterator[t.List[T]]:
 class VectorIndex(Component):
     """
     A component carrying the information to apply a vector index to a ``DB`` instance
-
-    :param identifier: unique string identifier of index
-    :param indexing_listener: listener which is applied to created vectors
-    :param compatible_listener: listener which is applied to vectors to be compared
-    :param measure: measure to use for comparison
-    :param version: version of this index
-    :param metric_values: metric values for this index
-    :param type_id: type of this component
     """
 
+    #: Unique string identifier of index
     identifier: str
+
+    #: Listener which is applied to created vectors
     indexing_listener: t.Union[Listener, str]
+
+    #: Listener which is applied to vectors to be compared
     compatible_listener: t.Union[None, Listener, str] = None
 
+    #: Measure to use for comparison
     measure: VectorIndexMeasureType = VectorIndexMeasureType.cosine
+
+    #: version of this index
     version: t.Optional[int] = None
+
+    #: Metric values for this index
     metric_values: t.Optional[t.Dict] = dc.field(default_factory=dict)
+
+    #: Type of this component
     type_id: t.ClassVar[str] = 'vector_index'
 
     @override

--- a/superduperdb/db/base/cursor.py
+++ b/superduperdb/db/base/cursor.py
@@ -14,19 +14,23 @@ class SuperDuperCursor:
     """
     A cursor that wraps a cursor and returns ``Document`` wrapping
     a dict including ``Encodable`` objects.
-
-    :param raw_cursor: the cursor to wrap
-    :param id_field: the field to use as the document id
-    :param encoders: a dict of encoders to use to decode the documents
-    :param features: a dict of features to add to the documents
-    :param scores: a dict of scores to add to the documents
     """
 
+    #: the cursor to wrap
     raw_cursor: t.Any
+
+    #: the field to use as the document id
     id_field: str
+
+    #: a dict of encoders to use to decode the documents
     encoders: t.Dict[str, Encoder] = dc.field(default_factory=dict)
+
+    #: a dict of features to add to the documents
     features: t.Optional[t.Dict[str, str]] = None
+
+    #: a dict of scores to add to the documents
     scores: t.Optional[t.Dict[str, float]] = None
+
     _it: int = 0
 
     @cached_property

--- a/superduperdb/db/ibis/query.py
+++ b/superduperdb/db/ibis/query.py
@@ -28,17 +28,18 @@ class QueryType(enum.Enum):
 
 @dc.dataclass
 class Table(Component):
-    '''
-    This is a representation of a table in ibis.
-    '''
+    """This is a representation of an SQL table in ibis."""
 
-    # The name of the table
+    #: The name of the table
     identifier: str
-    # The schema of the table
+
+    #: The schema of the table
     schema: t.Optional[IbisSchema] = None
-    # The table object
+
+    #: The table object
     table: t.Any = None
-    # Primary id of the table
+
+    #: Primary id of the table
     primary_id: str = 'id'
 
     #: A unique name for the class
@@ -91,13 +92,13 @@ class Table(Component):
         return mutated_args
 
     def __getattr__(self, k: str) -> 'QueryLinker':
-        '''
+        """
         This method is responsible for dynamically creating a query chain,
         which can be executed on a database. This is done by creating a
         QueryLinker object, which is a representation of a query chain.
         Under the hood, this is done by creating a QueryChain object, which
         is a representation of a query chain.
-        '''
+        """
 
         if k in self.__dict__:
             return self.__getattr__(k)
@@ -111,14 +112,14 @@ class Table(Component):
         )
 
     def like(self, r: t.Any = None, n: int = 10, vector_index: t.Optional[str] = None):
-        '''
+        """
         This appends a query to the query chain where the query is repsonsible
         for performing a vector search on the parent query chain inputs.
 
         :param r: The vector to search for
         :param n: The number of results to return
         :param vector_index: The vector index to use
-        '''
+        """
         k = 'prelike'
         kwargs = {'r': r, 'n': n, 'vector_index': vector_index}
         query = Query(k, args=[], sddb_kwargs=kwargs)
@@ -133,7 +134,7 @@ class Table(Component):
         valid_prob: float = 0.05,
         **kwargs,
     ):
-        '''
+        """
         This appends a query to the query chain where the query is repsonsible
         for inserting data into the table.
 
@@ -142,7 +143,7 @@ class Table(Component):
         :param verbose: Whether to print the progress of the insert
         :param encoders: The encoders to use
         :param valid_prob: The probability of validating the data
-        '''
+        """
         sddb_kwargs = {
             'refresh': refresh,
             'verbose': verbose,
@@ -167,7 +168,7 @@ class Table(Component):
 
 
 class Query:
-    '''
+    """
     This is a representation of a single query object in ibis query chain.
     This is used to build a query chain that can be executed on a database.
     Query will be executed in the order they are added to the chain.
@@ -184,7 +185,7 @@ class Query:
     :param kwargs: The keyword arguments to pass to the query
     :param sddb_kwargs: The keyword arguments from sddb to pass to the query
     :param connection_parent: If True, the parent of the query will be the connection
-    '''
+    """
 
     def __init__(
         self,
@@ -239,14 +240,14 @@ class Query:
 
 
 class QueryChain:
-    '''
+    """
     This is a representation of a query chain. This is used to build a query chain
     that can be executed on a database. Query will be executed in the order they are
     added to the chain.
 
     :param seed: The seed to start the chain with
     :param type: The type of the seed, either `query` or `attr`
-    '''
+    """
 
     def __init__(
         self,
@@ -292,23 +293,24 @@ class QueryChain:
 
 @dc.dataclass
 class OutputTable:
-    '''
-    This is a representation of model output table in ibis
-    '''
+    """This is a representation of model output table in ibis"""
 
-    # The name of the table
+    #: The name of the table
     model: str
-    # Primary id of the table
+
+    #: Primary id of the table
     primary_id: str = 'id'
-    # The table object
+
+    #: The table object
     table: t.Any = None
-    # The schema of the table
+
+    #: The schema of the table
     output_type: t.Any = None
 
     def create(self, conn: t.Any):
-        '''
+        """
         Create the table in the database
-        '''
+        """
         self.table = conn.create_table(self.model, schema=self.schema)
         return self.table
 
@@ -334,15 +336,17 @@ class OutputTable:
 
 @dc.dataclass
 class InMemoryTable(Component):
-    '''
+    """
     This is a representation of a table in memory (memtable) in ibis.
-    '''
+    """
 
-    # The name of the table
+    #: The name of the table
     identifier: str
-    # The table object
+
+    #: The table object
     table: t.Any = None
-    # Primary id of the table
+
+    #: Primary id of the table
     primary_id: str = 'id'
 
     type_id: t.ClassVar[str] = 'inmemory_table'
@@ -351,13 +355,13 @@ class InMemoryTable(Component):
         return args
 
     def __getattr__(self, k):
-        '''
+        """
         This method is responsible for dynamically creating a query chain,
         which can be executed on a database. This is done by creating a
         QueryLinker object, which is a representation of a query chain.
         Under the hood, this is done by creating a QueryChain object, which
         is a representation of a query chain.
-        '''
+        """
         if k in self.__dict__:
             return self.__getattr__(k)
 
@@ -390,13 +394,13 @@ class _LogicalExprMixin:
 
 @dc.dataclass
 class QueryLinker(Serializable, _LogicalExprMixin):
-    '''
+    """
     This class is responsible for linking together a query chain. It is
     responsible for creating a query chain, which is a representation of a
     ibis query. This is done by creating a QueryChain object, which creates
     a list of `Query` objects. Each `Query` object is a representation of
     a query in the query chain.
-    '''
+    """
 
     # The table that this query chain is linked.
     # This table is the parent ibis table.
@@ -449,7 +453,7 @@ class QueryLinker(Serializable, _LogicalExprMixin):
         return parent
 
     def outputs(self, model: str, db: DB):
-        '''
+        """
         This method is responsible for returning the outputs of a model.
         It is used to get the outputs of a model from a ibis query chain.
         Example:
@@ -457,7 +461,7 @@ class QueryLinker(Serializable, _LogicalExprMixin):
         The above query will return the outputs of the `model_name` model
         with t.filter() ids.
 
-        '''
+        """
         curr_query = self.build(db)
         model_table = db.db.table(model)
         query = curr_query.join(
@@ -502,7 +506,7 @@ class QueryLinker(Serializable, _LogicalExprMixin):
         db.execute(Table(model).insert(table_record))
 
     def __call__(self, *args, **kwargs):
-        '''
+        """
         This method is responsible to mutate the arguments of a query and
         return a new QueryLinker object with updated members.
         The last member of the query chain is updated with theses mutated arguments.
@@ -517,7 +521,7 @@ class QueryLinker(Serializable, _LogicalExprMixin):
         `image::encodable::pil_image`. So, we need to mutate the args to
         `['name', 'age', 'image::encodable::pil_image']`.
 
-        '''
+        """
         args = self.collection.mutate_args(args)
 
         # TODO: handle kwargs
@@ -594,12 +598,12 @@ class PreLike:
         pass
 
     def post(self, db, output, table=None, ibis_table=None, args=[], kwargs={}):
-        '''
+        """
 
         ids, _ = db._select_nearest(
             like=self.r, vector_index=self.vector_index, n=self.n
         )
-        '''
+        """
         ids = [1, 2, 3]
         f = output.filter(ibis_table.__getattr__(self.primary_id).isin(ids))
         return f
@@ -618,10 +622,10 @@ class Insert:
 
     def pre(self, db, table=None, **kwargs):
         # TODO: handle adding table later
-        '''
+        """
         if self.base_table.identifier not in db.tables:
             db.add(self.base_table)
-        '''
+        """
         for e in self.encoders:
             db.add(e)
 

--- a/superduperdb/db/mongodb/query.py
+++ b/superduperdb/db/mongodb/query.py
@@ -23,11 +23,7 @@ if t.TYPE_CHECKING:
 
 @dc.dataclass
 class Collection(Serializable):
-    """
-    MongoDB collection wrapper
-
-    :param name: The name of the collection
-    """
+    """Collection wrapper"""
 
     #: The name of this Collection
     name: str
@@ -207,26 +203,26 @@ class Collection(Serializable):
 
 @dc.dataclass
 class ReplaceOne(Update):
-    """
-    A query that replaces one record in a collection
-
-    :param collection: The collection to perform the query on
-    :param filter: Filter results by this dictionary
-    :param update: The update to apply
-    :param args: Positional query arguments to ``pymongo.Collection.replace_one``
-    :param kwargs: Named query arguments to ``pymongo.Collection.replace_one``
-    :param refresh: If true, refresh the model outputs
-    :param verbose: If true, print more logging
-    """
+    """A query that replaces one record in a collection"""
 
     #: The collection to perform the query on
     collection: Collection
-
+    #: Filter results by this dictionary
     filter: t.Dict
+
+    #: The update to apply
     update: Document
+
+    #: Positional query arguments to ``pymongo.Collection.replace_one``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.replace_one``
     kwargs: t.Dict = dc.field(default_factory=dict)
+
+    #: If true, refresh the model outputs
     refresh: bool = True
+
+    #: If true, print more logging
     verbose: bool = True
 
     type_id: t.Literal['mongodb.ReplaceOne'] = 'mongodb.ReplaceOne'
@@ -251,19 +247,20 @@ class ReplaceOne(Update):
 
 @dc.dataclass
 class PreLike(Like):
-    """
-    A query that returns documents like another document
+    """A query that returns documents like another document"""
 
-    :param collection: The collection to perform the query on
-    :param r: The document to match
-    :param vector_index: The name of the vector index to use
-    :param n: The number of documents to return
-    """
-
+    #: The collection to perform the query on
     r: Document
+
+    #: The document to match
     vector_index: str
+
+    #: The name of the vector index to use
     collection: Collection
+
+    #: The number of documents to return
     n: int = 100
+
     type_id: t.Literal['mongodb.PreLike'] = 'mongodb.PreLike'
 
     @property
@@ -332,20 +329,22 @@ class PreLike(Like):
 
 @dc.dataclass
 class Find(Select):
-    """
-    A query to find couments
-
-    :param collection: The collection to perform the query on
-    :param like_parent: The parent query to use for the like query (if applicable)
-    :param args: Positional query arguments to ``pymongo.Collection.find``
-    :param kwargs: Named query arguments to ``pymongo.Collection.find``
-    """
+    """A query to find documents"""
 
     id_field: t.ClassVar[str] = '_id'
+
+    #: The collection to perform the query on
     collection: t.Optional[Collection] = None
+
+    #: The parent query to use for the like query (if applicable)
     like_parent: t.Optional[PreLike] = None
+
+    #: Positional query arguments to ``pymongo.Collection.find``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.find``
     kwargs: t.Dict = dc.field(default_factory=dict)
+
     type_id: t.Literal['mongodb.Find'] = 'mongodb.Find'
 
     def select_single_id(self, id, db, encoders=()):
@@ -573,21 +572,18 @@ class Find(Select):
 class CountDocuments(Select):
     """
     A query to count documents
-
-    :param collection: The collection to perform the query on
-    :param like_parent: The parent query to use for the like query (if applicable)
-    :param args: Positional query arguments to ``pymongo.Collection.count_documents``
-    :param kwargs: Named query arguments to ``pymongo.Collection.count_documents``
     """
 
     #: The collection to perform the query on
     collection: t.Optional[Collection] = None
+
+    #: The parent query to use for the like query (if applicable)
     like_parent: t.Optional[PreLike] = None
 
-    #: Positional query arguments
+    #: Positional query arguments to ``pymongo.Collection.count_documents``
     args: t.Sequence = dc.field(default_factory=list)
 
-    #: Named query arguments
+    #: Named query arguments to ``pymongo.Collection.count_documents``
     kwargs: t.Dict = dc.field(default_factory=dict)
 
     #: Uniquely identifies serialized elements of this class
@@ -618,22 +614,23 @@ class FeaturizeOne(SelectOne):
 
 @dc.dataclass
 class FindOne(SelectOne):
-    """
-    A query to find one document.
-
-    :param collection: The collection to perform the query on
-    :param like_parent: The parent query to use for the like query (if applicable)
-    :param args: Positional query arguments to ``pymongo.Collection.find_one``
-    :param kwargs: Named query arguments to ``pymongo.Collection.find_one``
-    """
+    """A query to find one document."""
 
     # TODO add this to a base class (should be created)
     id_field: t.ClassVar[str] = '_id'
 
+    #: The collection to perform the query on
     collection: t.Optional[Collection] = None
+
+    #: The parent query to use for the like query (if applicable)
     like_parent: t.Optional[PreLike] = None
+
+    #: Positional query arguments to ``pymongo.Collection.find_one``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.find_one``
     kwargs: t.Dict = dc.field(default_factory=dict)
+
     type_id: t.Literal['mongodb.FindOne'] = 'mongodb.FindOne'
 
     @override
@@ -656,18 +653,18 @@ class FindOne(SelectOne):
 
 @dc.dataclass
 class Aggregate(Select):
-    """
-    An aggregate query
+    """An aggregate query"""
 
-    :param collection: The collection to perform the query on
-    :param args: Positional query arguments to ``pymongo.Collection.aggregate``
-    :param kwargs: Named query arguments to ``pymongo.Collection.aggregate``
-    :param vector_index: The name of the vector index to use
-    """
-
+    #: The collection to perform the query on
     collection: Collection
+
+    #: Positional query arguments to ``pymongo.Collection.aggregate``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.aggregate``
     kwargs: t.Dict = dc.field(default_factory=dict)
+
+    #: The name of the vector index to use
     vector_index: t.Optional[str] = None
 
     type_id: t.Literal['mongodb.Aggregate'] = 'mongodb.Aggregate'
@@ -719,16 +716,15 @@ class Aggregate(Select):
 
 @dc.dataclass
 class DeleteOne(Delete):
-    """
-    A query to delete a single document
+    """A query to delete a single document"""
 
-    :param collection: The collection to perform the query on
-    :param args: Positional query arguments to ``pymongo.Collection.delete_one``
-    :param kwargs: Named query arguments to ``pymongo.Collection.delete_one``
-    """
-
+    #: The collection to perform the query on
     collection: Collection
+
+    #: Positional query arguments to ``pymongo.Collection.delete_one``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.delete_one``
     kwargs: t.Dict = dc.field(default_factory=dict)
 
     type_id: t.Literal['mongodb.DeleteOne'] = 'mongodb.DeleteOne'
@@ -740,16 +736,15 @@ class DeleteOne(Delete):
 
 @dc.dataclass
 class DeleteMany(Delete):
-    """
-    A query to delete many documents
+    """A query to delete many documents"""
 
-    :param collection: The collection to perform the query on
-    :param args: Positional query arguments to ``pymongo.Collection.delete_many``
-    :param kwargs: Named query arguments to ``pymongo.Collection.delete_many``
-    """
-
+    #: The collection to perform the query on
     collection: Collection
+
+    #: Positional query arguments to ``pymongo.Collection.delete_many``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.delete_many``
     kwargs: t.Dict = dc.field(default_factory=dict)
 
     type_id: t.Literal['mongodb.DeleteMany'] = 'mongodb.DeleteMany'
@@ -761,19 +756,12 @@ class DeleteMany(Delete):
 
 @dc.dataclass
 class UpdateOne(Update):
-    """
-    A query that updates one document
-
-    :param collection: The collection to perform the query on
-    :param update: The update to apply
-    :param filter: Filter results by this dictionary
-    :param refresh: If true, refresh the underlying collection
-    :param args: Positional query arguments to ``pymongo.Collection.update_one``
-    :param kwargs: Named query arguments to ``pymongo.Collection.update_one``
-    """
+    """A query that updates one document"""
 
     #: The collection to perform the query on
     collection: Collection
+
+    #: The update to apply
     update: t.Any
 
     #: Filter results by this dictionary
@@ -785,10 +773,10 @@ class UpdateOne(Update):
     #: If true, print more logging
     verbose: bool = True
 
-    #: Positional query arguments
+    #: Positional query arguments to ``pymongo.Collection.update_one``
     args: t.Sequence = dc.field(default_factory=list)
 
-    #: Named query arguments
+    #: Named query arguments to ``pymongo.Collection.update_one``
     kwargs: t.Dict = dc.field(default_factory=dict)
 
     #: Uniquely identifies serialized elements of this class
@@ -867,25 +855,29 @@ class UpdateMany(Update):
 
 @dc.dataclass
 class InsertMany(Insert):
-    """
-    A query that inserts many documents
+    """A query that inserts many documents"""
 
-    :param collection: The collection to perform the query on
-    :param documents: The documents to insert
-    :param refresh: If true, refresh the underlying collection
-    :param verbose: If true, print more logging
-    :param args: Positional query arguments to ``pymongo.Collection.insert_many``
-    :param kwargs: Named query arguments to ``pymongo.Collection.insert_many``
-    :param encoders: Encoders to use
-    """
-
+    #: The collection to perform the query on
     collection: Collection
+
+    #: The documents to insert
     documents: t.List[Document] = dc.field(default_factory=list)
+
+    #: If true, refresh the underlying collection
     refresh: bool = True
+
+    #: If true, print more logging
     verbose: bool = True
+
+    #: Positional query arguments to ``pymongo.Collection.insert_many``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.insert_many``
     kwargs: t.Dict = dc.field(default_factory=dict)
+
+    #: Encoders to use
     encoders: t.Sequence = dc.field(default_factory=list)
+
     type_id: t.Literal['mongodb.InsertMany'] = 'mongodb.InsertMany'
 
     @property
@@ -935,20 +927,21 @@ class InsertMany(Insert):
 
 @dc.dataclass
 class PostLike(Select):
-    """
-    Find documents like this one
+    """Find documents like this one"""
 
-    :param find_parent: The parent query to use for the like query (if applicable)
-    :param r: The document to match
-    :param vector_index: The name of the vector index to use
-    :param n: The number of documents to return
-    :param max_ids: The maximum number of ids to use for the like query
-    """
-
+    #: The parent query to use for the like query (if applicable)
     find_parent: t.Optional[Find]
+
+    #: The document to match
     r: Document
+
+    #: The name of the vector index to use
     vector_index: str
+
+    #: The number of documents to return
     n: int = 100
+
+    #: The maximum number of ids to use for the like query
     max_ids: int = 1000
 
     type_id: t.Literal['mongodb.PostLike'] = 'mongodb.PostLike'
@@ -976,14 +969,12 @@ class PostLike(Select):
 
 @dc.dataclass
 class Featurize(Select):
-    """
-    A feature-extraction query
+    """A feature-extraction query"""
 
-    :param features: The features to extract
-    :param parent: The parent query to use for the like query (if applicable)
-    """
-
+    #: The features to extract
     features: t.Dict[str, str]
+
+    #: The parent query to use for the like query (if applicable)
     parent: Find
 
     type_id: t.Literal['mongodb.Featurize'] = 'mongodb.Featurize'
@@ -1055,14 +1046,12 @@ class Featurize(Select):
 
 @dc.dataclass
 class Limit(Select):
-    """
-    A query that limits the number of returned documents
+    """A query that limits the number of returned documents"""
 
-    :param n: The number of documents to return
-    :param parent: The parent query to use for the like query (if applicable)
-    """
-
+    #: The number of documents to return
     n: int
+
+    #: The parent query to use for the like query (if applicable)
     parent: t.Union[Featurize, Find, PreLike, PostLike]
 
     type_id: t.Literal['mongodb.Limit'] = 'mongodb.Limit'
@@ -1074,16 +1063,15 @@ class Limit(Select):
 
 @dc.dataclass
 class ChangeStream:
-    """
-    Request a stream of changes from a db
+    """Request a stream of changes from a db"""
 
-    :param collection: The collection to perform the query on
-    :param args: Positional query arguments to ``pymongo.Collection.watch``
-    :param kwargs: Named query arguments to ``pymongo.Collection.watch``
-    """
-
+    #: The collection to perform the query on
     collection: Collection
+
+    #: Positional query arguments to ``pymongo.Collection.watch``
     args: t.Sequence = dc.field(default_factory=list)
+
+    #: Named query arguments to ``pymongo.Collection.watch``
     kwargs: t.Dict = dc.field(default_factory=dict)
 
     @override

--- a/superduperdb/ext/openai/model.py
+++ b/superduperdb/ext/openai/model.py
@@ -32,20 +32,21 @@ def _available_models():
 
 @dc.dataclass
 class OpenAI(Component, PredictMixin):
-    """
-    OpenAI predictor.
+    """OpenAI predictor."""
 
-    :param model: The model to use, e.g. ``'text-embedding-ada-002'``.
-    :param identifier: The identifier to use, e.g. ``'my-model'``.
-    :param version: The version to use, e.g. ``0`` (leave empty)
-    :param takes_context: Whether the model takes context into account.
-    :param encoder: The encoder identifier.
-    """
-
+    #: The model to use, e.g. ``'text-embedding-ada-002'``.
     model: str
+
+    #: The identifier to use, e.g. ``'my-model'``.
     identifier: str = ''
+
+    #: The version to use, e.g. ``0`` (leave empty)
     version: t.Optional[int] = None
+
+    #: Whether the model takes context into account.
     takes_context: bool = False
+
+    #: The encoder identifier.
     encoder: t.Union[Encoder, str, None] = None
 
     #: A unique name for the class
@@ -70,13 +71,11 @@ class OpenAI(Component, PredictMixin):
 
 @dc.dataclass
 class OpenAIEmbedding(OpenAI):
-    """
-    OpenAI embedding predictor.
-
-    :param shape: The shape as ``tuple`` of the embedding.
-    """
+    """OpenAI embedding predictor"""
 
     shapes: t.ClassVar[t.Dict] = {'text-embedding-ada-002': (1536,)}
+
+    #: The shape as ``tuple`` of the embedding.
     shape: t.Optional[t.Sequence[int]] = None
 
     def __post_init__(self):
@@ -126,14 +125,12 @@ class OpenAIEmbedding(OpenAI):
 
 @dc.dataclass
 class OpenAIChatCompletion(OpenAI):
-    """
-    OpenAI chat completion predictor.
+    """OpenAI chat completion predictor."""
 
-    :param takes_context: Whether the model takes context into account.
-    :param prompt: The prompt to use to seed the response.
-    """
-
+    #: Whether the model takes context into account.
     takes_context: bool = True
+
+    #: The prompt to use to seed the response.
     prompt: t.Optional[str] = None
 
     def _format_prompt(self, context, X):

--- a/superduperdb/ext/torch/model.py
+++ b/superduperdb/ext/torch/model.py
@@ -56,31 +56,39 @@ class BasicDataset(data.Dataset):
 class TorchTrainerConfiguration(_TrainingConfiguration):
     """
     Configuration for the PyTorch trainer.
-
-    :param objective: objective function
-    :param loader_kwargs: kwargs for the dataloader
-    :param max_iterations: maximum number of iterations
-    :param no_improve_then_stop: number of iterations to wait for improvement
-                                 before stopping
-    :param splitter: splitter for the data
-    :param download: whether to download the data
-    :param validation_interval: how often to validate
-    :param listen: which metric to listen to for early stopping
-    :param optimizer_cls: optimizer class
-    :param optimizer_kwargs: kwargs for the optimizer
-    :param target_preprocessors: preprocessors for the target
     """
 
+    #: Objective function
     objective: t.Optional[t.Union[Artifact, t.Callable]] = None
+
+    #: Kwargs for the dataloader
     loader_kwargs: t.Dict = dc.field(default_factory=dict)
+
+    #: Maximum number of iterations
     max_iterations: int = 10**100
+
+    #: Number of iterations to wait for improvement before stopping
     no_improve_then_stop: int = 5
+
+    #: Splitter for the data
     splitter: t.Optional[Artifact] = None
+
+    #: Whether to download the data
     download: bool = False
+
+    #: How often to validate
     validation_interval: int = 100
+
+    #: Which metric to listen to for early stopping
     listen: str = 'objective'
+
+    #: Optimizer class
     optimizer_cls: Artifact = Artifact(torch.optim.Adam, serializer='pickle')
+
+    #: Kwargs for the optimizer
     optimizer_kwargs: t.Dict = dc.field(default_factory=dict)
+
+    #: Preprocessors for the target
     target_preprocessors: t.Optional[t.Union[Artifact, t.Dict]] = None
 
     def __post_init__(self):
@@ -346,15 +354,14 @@ class Base:
 
 @dc.dataclass
 class TorchModel(Base, Model):  # type: ignore[misc]
+    #: optional optimizer state, populated automatically on reload
     optimizer_state: t.Optional[Artifact] = None
-    forward_method: str = '__call__'
-    train_forward_method: str = '__call__'
 
-    """
-    :param optimizer_state: optional optimizer state, populated automatically on reload
-    :param forward_method: method to call for prediction, defaults to __call__
-    :param train_forward_method: method to call for training, defaults to __call__
-    """
+    #: method to call for prediction, defaults to __call__
+    forward_method: str = '__call__'
+
+    #: method to call for training, defaults to __call__
+    train_forward_method: str = '__call__'
 
     def __post_init__(self):
         super().__post_init__()

--- a/superduperdb/ext/transformers/model.py
+++ b/superduperdb/ext/transformers/model.py
@@ -33,18 +33,18 @@ def TransformersTrainerConfiguration(identifier: str, *args, **kwargs):
 
 @dc.dataclass
 class Pipeline(Model):
-    """
-    A wrapper for ``transformers.Pipeline``.
+    """A wrapper for ``transformers.Pipeline``."""
 
-    :param preprocess_type: The type of preprocessing to use {'tokenizer'}
-    :param preprocess_kwargs: The type of preprocessing to use. Currently only
-    :param postprocess_kwargs: The type of postprocessing to use.
-    :param task: The task to use for the pipeline.
-    """
-
+    #: The type of preprocessing to use {'tokenizer'}
     preprocess_type: str = 'tokenizer'
+
+    #: The type of preprocessing to use. Currently only
     preprocess_kwargs: t.Dict[str, t.Any] = dc.field(default_factory=dict)
+
+    #: The type of postprocessing to use.
     postprocess_kwargs: t.Dict[str, t.Any] = dc.field(default_factory=dict)
+
+    #: The task to use for the pipeline.
     task: str = 'text-classification'
 
     def __post_init__(self):

--- a/superduperdb/misc/retry.py
+++ b/superduperdb/misc/retry.py
@@ -14,21 +14,22 @@ class Retry:
     Retry a function until it succeeds.
 
     This is a thin wrapper around the tenacity retry library, using our configs.
-
-    :param exception_types: The exception types to retry on.
-    :param cfg: The retry config.
     """
 
+    #: The exception types to retry on.
     exception_types: ExceptionTypes
-    cfg: s.config.Retry = dc.field(default_factory=lambda: s.CFG.apis.retry)
+
+    #: The retry config.
+    cfg: t.Optional[s.config.Retry] = None
 
     def __call__(self, f: t.Callable) -> t.Any:
+        cfg = self.cfg or s.CFG.apis.retry
         retry = tenacity.retry_if_exception_type(self.exception_types)
-        stop = tenacity.stop_after_attempt(self.cfg.stop_after_attempt)
+        stop = tenacity.stop_after_attempt(cfg.stop_after_attempt)
         wait = tenacity.wait_exponential(
-            max=self.cfg.wait_max,
-            min=self.cfg.wait_min,
-            multiplier=self.cfg.wait_multiplier,
+            max=cfg.wait_max,
+            min=cfg.wait_min,
+            multiplier=cfg.wait_multiplier,
         )
         retrier = tenacity.retry(retry=retry, stop=stop, wait=wait)
         return retrier(f)

--- a/superduperdb/vector_search/lancedb_client.py
+++ b/superduperdb/vector_search/lancedb_client.py
@@ -68,16 +68,15 @@ VECTOR_FIELD_NAME = "vector"
 
 @dc.dataclass
 class LanceTable:
-    """
-    A ``LanceTable`` within a ``LanceDBClient``.
+    """A ``LanceTable`` within a ``LanceDBClient``."""
 
-    :param client: ``LanceDBClient`` instance.
-    :param table: ``LanceTable`` instance.
-    :param measure: Distance measure for vector search. Defaults to 'cosine'.
-    """
-
+    #: ``LanceDBClient`` instance.
     client: lancedb.db.LanceDBConnection
+
+    #: ``LanceTable`` instance.
     table: lancedb.table.LanceTable
+
+    #: Distance measure for vector search. Defaults to 'cosine'.
     measure: str = "cosine"
 
     def get(self, identifier: str, limit: int = 1) -> t.List[t.Any]:


### PR DESCRIPTION
Looks much better now!

----

I tried to get rid of the silly pydantic fields by putting this in docs/conf.py:

```
def _skip_member(app, what, name, obj, skip, options):
    return name in ('model_config', 'model_fields') or None


def setup(app):
    app.connect('autodoc-skip-member', _skip_member)
```

`_skip_member` did get called, but never with the members of the actual classes.