### PR TITLE
Replace cdc global with collection locks

### DIFF
--- a/superduperdb/base/config.py
+++ b/superduperdb/base/config.py
@@ -50,10 +50,6 @@ class Cluster(JSONable):
 
     #: Whether the connection is local
     local: bool = True
-
-    #: Whether change data capture should be used
-    cdc: bool = False
-
     backfill_batch_size: int = 100
 
 

--- a/superduperdb/db/ibis/query.py
+++ b/superduperdb/db/ibis/query.py
@@ -5,7 +5,6 @@ import typing as t
 import ibis
 from ibis.expr.types.relations import Table as IbisTable
 
-from superduperdb import CFG
 from superduperdb.container.component import Component
 from superduperdb.container.document import Document
 from superduperdb.container.encoder import Encoder
@@ -641,9 +640,8 @@ class Insert:
     def post(self, db, output, *args, **kwargs):
         graph = None
         [_id for _id in kwargs['pre_output']['ids']]
-        if self.refresh and not CFG.cluster.cdc:
-            # TODO: add refresh functionality
-            pass
+        # TODO: add refresh functionality
+
         return graph, output
 
 

--- a/superduperdb/db/mongodb/__init__.py
+++ b/superduperdb/db/mongodb/__init__.py
@@ -1,0 +1,3 @@
+import typing as t
+
+CDC_COLLECTION_LOCKS: t.Dict[str, bool] = {}

--- a/superduperdb/db/mongodb/cdc.py
+++ b/superduperdb/db/mongodb/cdc.py
@@ -12,14 +12,13 @@ from enum import Enum
 from bson.objectid import ObjectId as BsonObjectId
 from pymongo.change_stream import CollectionChangeStream
 
-import superduperdb as s
 from superduperdb import logging
 from superduperdb.container.job import FunctionJob
 from superduperdb.container.serializable import Serializable
 from superduperdb.container.task_workflow import TaskWorkflow
 from superduperdb.container.vector_index import VectorIndex
 from superduperdb.db.base.db import DB
-from superduperdb.db.mongodb import query
+from superduperdb.db.mongodb import CDC_COLLECTION_LOCKS, query
 from superduperdb.misc.task_queue import cdc_queue
 from superduperdb.vector_search.base import VectorCollectionConfig, VectorCollectionItem
 
@@ -679,7 +678,8 @@ class MongoDatabaseListener(BaseDatabaseListener, MongoEventMixin):
         for more fine grained listening.
         """
         try:
-            s.CFG.cluster.cdc = True
+            CDC_COLLECTION_LOCKS[self._on_component.name] = True
+
             self._stop_event.clear()
             if self._scheduler:
                 if self._scheduler.is_alive():
@@ -703,7 +703,8 @@ class MongoDatabaseListener(BaseDatabaseListener, MongoEventMixin):
             self._startup_event.wait(timeout=timeout)
         except Exception:
             logging.error('Listening service stopped!')
-            s.CFG.cluster.cdc = False
+            CDC_COLLECTION_LOCKS.pop(self._on_component.name, None)
+
             self.stop()
             raise
 
@@ -724,7 +725,8 @@ class MongoDatabaseListener(BaseDatabaseListener, MongoEventMixin):
         Stop listening cdc changes.
         This stops the corresponding services as well.
         """
-        s.CFG.cluster.cdc = False
+        CDC_COLLECTION_LOCKS.pop(self._on_component.name, None)
+
         self._stop_event.set()
         self._cdc_change_handler.join()
         if self._scheduler:

--- a/superduperdb/db/mongodb/query.py
+++ b/superduperdb/db/mongodb/query.py
@@ -12,6 +12,7 @@ from pymongo import UpdateOne as _UpdateOne
 import superduperdb as s
 from superduperdb.container.document import Document
 from superduperdb.container.serializable import Serializable
+from superduperdb.db.mongodb import CDC_COLLECTION_LOCKS
 
 from ..base.cursor import SuperDuperCursor
 from ..base.query import Delete, Insert, Like, Select, SelectOne, Update
@@ -836,7 +837,7 @@ class UpdateMany(Update):
             **self.kwargs,
         )
         graph = None
-        if self.refresh and not s.CFG.cluster.cdc:
+        if self.refresh and not CDC_COLLECTION_LOCKS.get(self.collection.name, False):
             graph = db.refresh_after_update_or_insert(
                 query=self, ids=ids, verbose=self.verbose
             )
@@ -916,7 +917,7 @@ class InsertMany(Insert):
             **self.kwargs,
         )
         graph = None
-        if self.refresh and not s.CFG.cluster.cdc:
+        if self.refresh and not CDC_COLLECTION_LOCKS.get(self.collection.name, False):
             graph = db.refresh_after_update_or_insert(
                 query=self,
                 ids=output.inserted_ids,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description
Might resolve 
https://github.com/SuperDuperDB/superduperdb/issues/878

So this pr create a collection specific cdc lock

which means 

if a user creates cdc listener on `Collection1`

and uses Collection.insert on `Collection2`, here we don't want to block run task workflow 


<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
