### PR TITLE
Add commit message release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,15 @@
 name: Release
 on:
-  workflow_dispatch:  # allows triggering a github action manually - see 'Actions' tab
+  push:
+    branches:
+      - main
 
 jobs:
   build:
+    # Any commit message that contains the phrase 'Update to version' will trigger the release process.
+    # We have an additional safety mechanism in the upload to PyPI step that requires manual approval.
+    # This is to prevent accidental releases. All other steps (eg build, upload to GitHub) are reversible
+    if: ${{ startsWith(github.event.head_commit.message, 'Update to version') }}
     runs-on: ubuntu-latest
     defaults:
         run:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This adds a trigger to the action to only run the action when a PR is merged to main AND the head commit message contains the text 'Update to version'.

It's janky, but it requires minimal intervention.

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
