### PR TITLE
Add npm build of docusaurus to regular build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,10 +1,10 @@
-name: Documentation
+name: New documentation
 on:
-  push:
-    branches:
-      - main
-    paths:  # only run this action when the docs folder is changed
-      - 'docs/**'
+push:
+  branches:
+    - main
+  paths:  # only run this action when the newdocs folder is changed
+    - 'newdocs/content/**'
 
 # allow the action to write to the gh-pages branch
 permissions:
@@ -22,6 +22,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
+          sudo apt-get install nodejs npm
 
       - name: Set up Python 3.10
         id: setup-python
@@ -38,20 +39,31 @@ jobs:
             ${{ env.pythonLocation }}
           key: 3.10-ubuntu-latest-${{ hashFiles('.github/ci-pinned-requirements/docs.txt') }}
 
+      - name: Build docs and use-cases
+        run: |
+          cd newdocs
+          npm i
+          npm run build
+          cd ..
+
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r .github/ci-pinned-requirements/docs.txt
     
-      - name: Build docs
+      - name: Build api docs
         # doc build is available in .cache/docs
         run: |
           python -m superduperdb docs
 
+      - name: Copy api docs to build directory
+        run: |
+          cp -r .cache/docs newdocs/build/apidocs
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .cache/docs
+          publish_dir: newdocs/build
           cname: docs.superduperdb.com
           enable_jekyll: true

--- a/newdocs/docusaurus.config.js
+++ b/newdocs/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
   organizationName: 'SuperDuperDB', // Usually your GitHub org/user name.
   projectName: 'superduperdb', // Usually your repo name.
 
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internalization, you can use this field to set useful
@@ -86,7 +86,7 @@ const config = {
           },
         //   {to: '/blog', label: 'Blog', position: 'left'},
           {
-            href: 'https://docs.superduperdb.com/source/modules.html',
+            href: 'https://docs.superduperdb.com/apidocs/source/superduperdb.html',
             label: 'API',
             position: 'left',
           },

--- a/newdocs/src/components/HomepageFeatures/index.js
+++ b/newdocs/src/components/HomepageFeatures/index.js
@@ -4,29 +4,31 @@ import styles from './styles.module.css';
 
 const FeatureList = [
   {
-    title: 'Easy to Use',
+    title: 'Bring AI to your data store',
     description: (
       <>
-        Docusaurus was designed from the ground up to be easily installed and
-        used to get your website up and running quickly.
+        Easily deploy, train and manage any AI models and APIs on your datastore: 
+        from LLMs, public APIs to highly custom machine learning models, 
+        use-cases and workflows.
       </>
     ),
   },
   {
-    title: 'Focus on What Matters',
+    title: 'Build AI applications on top of your datastore',
     description: (
       <>
-        Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
-        ahead and move your docs into the <code>docs</code> directory.
+        A single scalable deployment of all your AI models and APIs which is 
+        automatically kept up-to-date as new data is processed immediately.
       </>
     ),
   },
   {
-    title: 'Powered by React',
+    title: 'Work with any ML/AI frameworks and APIs',
     description: (
       <>
-        Extend or customize your website layout by reusing React. Docusaurus can
-        be extended while reusing the same header and footer.
+        Integrate and combine models from Sklearn, PyTorch, HuggingFace
+        with AI APIs such as OpenAI to build even the most complex AI
+        applications and workflows.
       </>
     ),
   },


### PR DESCRIPTION
Solves #845.

- Built docs are already online here: https://docs.superduperdb.com/
- This adds the new docs to the current docs build.

There is currently some redundancy in the old sphinx build and the new docusaurus+sphinx setup. 
This will be removed in #844.