### PR TITLE
Add Markdown link check to CI

### DIFF
--- a/.github/workflows/test-deps-and-links.yml
+++ b/.github/workflows/test-deps-and-links.yml
@@ -1,4 +1,4 @@
-name: test latest dependency versions
+name: test latest dependency versions and external web links
 
 on:
   schedule:
@@ -70,3 +70,9 @@ jobs:
 
             - name: Run tests
               run: make test
+
+    markdown-link-check:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This PR adds an action to our nightly cron job that also checks the links in our Markdown files. Suggested by comments in #900. 


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#910 

## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
