### PR TITLE
Add Anthropic Completions endpoint

### DIFF
--- a/.github/ci-pinned-requirements/dev.txt
+++ b/.github/ci-pinned-requirements/dev.txt
@@ -17,8 +17,11 @@ alabaster==0.7.13
     # via sphinx
 annotated-types==0.5.0
     # via pydantic
+anthropic==0.3.11
+    # via superduperdb
 anyio==3.7.1
     # via
+    #   anthropic
     #   fastapi
     #   httpcore
     #   starlette
@@ -118,6 +121,8 @@ dill==0.3.7
     #   superduperdb (pyproject.toml)
 distributed==2023.5.0
     # via dask
+distro==1.8.0
+    # via anthropic
 dnspython==2.4.2
     # via pymongo
 docutils==0.20.1
@@ -186,7 +191,9 @@ h11==0.14.0
 httpcore==0.18.0
     # via httpx
 httpx==0.25.0
-    # via superduperdb
+    # via
+    #   anthropic
+    #   superduperdb
 huggingface-hub==0.17.2
     # via
     #   accelerate
@@ -462,6 +469,7 @@ pyarrow==11.0.0
     #   pylance
 pydantic==2.3.0
     # via
+    #   anthropic
     #   fastapi
     #   lancedb
     #   superduperdb
@@ -654,7 +662,9 @@ threadpoolctl==3.2.0
 tinycss2==1.2.1
     # via nbconvert
 tokenizers==0.13.3
-    # via transformers
+    # via
+    #   anthropic
+    #   transformers
 toml==0.10.2
     # via interrogate
 tomli==2.0.1
@@ -723,6 +733,7 @@ types-urllib3==1.26.25.14
 typing-extensions==4.8.0
     # via
     #   annotated-types
+    #   anthropic
     #   black
     #   boto3-stubs
     #   botocore-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
 [project.optional-dependencies]
 apis = [
     "cohere",
+    "anthropic",
     ]
 torch = [
     "torch>=2.0.0,!=2.0.1",

--- a/superduperdb/ext/anthropic/__init__.py
+++ b/superduperdb/ext/anthropic/__init__.py
@@ -1,0 +1,3 @@
+from .model import AnthropicCompletions
+
+__all__ = ('AnthropicCompletions',)

--- a/superduperdb/ext/anthropic/model.py
+++ b/superduperdb/ext/anthropic/model.py
@@ -1,0 +1,101 @@
+import dataclasses as dc
+import typing as t
+
+import anthropic
+from anthropic import APIConnectionError, APIError, APIStatusError, APITimeoutError
+
+from superduperdb.container.component import Component
+from superduperdb.container.encoder import Encoder
+from superduperdb.container.model import PredictMixin
+from superduperdb.ext.utils import format_prompt, get_key
+from superduperdb.misc.retry import Retry
+
+retry = Retry(
+    exception_types=(APIConnectionError, APIError, APIStatusError, APITimeoutError)
+)
+
+KEY_NAME = 'ANTHROPIC_API_KEY'
+
+
+@dc.dataclass
+class Anthropic(Component, PredictMixin):
+    """Anthropic predictor."""
+
+    #: The model to use, e.g. ``'claude-2'``.
+    model: str
+
+    #: The identifier to use, e.g. ``'my-model'``.
+    identifier: str = ''
+
+    #: The version to use, e.g. ``0`` (leave empty)
+    version: t.Optional[int] = None
+
+    #: Whether the model takes context into account.
+    takes_context: bool = False
+
+    #: The encoder identifier.
+    encoder: t.Union[Encoder, str, None] = None
+
+    #: A unique name for the class
+    type_id: t.ClassVar[str] = 'model'
+
+    #: Keyword arguments to pass to the client
+    client_kwargs: t.Dict[str, t.Any] = dc.field(default_factory=dict)
+
+    def __post_init__(self):
+        self.identifier = self.identifier or self.model
+
+    @property
+    def child_components(self) -> t.Sequence[t.Tuple[str, str]]:
+        if self.encoder is not None:
+            return [('encoder', 'encoder')]
+        return []
+
+
+@dc.dataclass
+class AnthropicCompletions(Anthropic):
+    """Cohere completions (chat) predictor."""
+
+    #: Whether the model takes context into account.
+    takes_context: bool = True
+
+    #: The prompt to use to seed the response.
+    prompt: str = ''
+
+    @retry
+    def _predict_one(self, X, context: t.Optional[t.List[str]] = None, **kwargs):
+        if context is not None:
+            X = format_prompt(X, self.prompt, context=context)
+        client = anthropic.Anthropic(api_key=get_key(KEY_NAME), **self.client_kwargs)
+        resp = client.completions.create(prompt=X, model=self.identifier, **kwargs)
+        return resp.completion
+
+    @retry
+    async def _apredict_one(self, X, context: t.Optional[t.List[str]] = None, **kwargs):
+        if context is not None:
+            X = format_prompt(X, self.prompt, context=context)
+        client = anthropic.AsyncAnthropic(
+            api_key=get_key(KEY_NAME), **self.client_kwargs
+        )
+        resp = await client.completions.create(
+            prompt=X, model=self.identifier, **kwargs
+        )
+        return resp.completion
+
+    def _predict(
+        self, X, one: bool = True, context: t.Optional[t.List[str]] = None, **kwargs
+    ):
+        if context:
+            assert one, 'context only works with ``one=True``'
+        if one:
+            return self._predict_one(X, context=context, **kwargs)
+        return [self._predict_one(msg) for msg in X]
+
+    async def _apredict(
+        self, X, one: bool = True, context: t.Optional[t.List[str]] = None, **kwargs
+    ):
+        if context:
+            assert one, 'context only works with ``one=True``'
+        if one:
+            return await self._apredict_one(X, context=context, **kwargs)
+        return [await self._apredict_one(msg) for msg in X]

--- a/superduperdb/ext/utils.py
+++ b/superduperdb/ext/utils.py
@@ -9,10 +9,10 @@ def str_shape(shape: t.Sequence[int]) -> str:
 
 
 def get_key(key_name: str) -> str:
-    if key_name not in os.environ:
-        raise ValueError(f'{key_name} not set')
-    else:
+    try:
         return os.environ[key_name]
+    except KeyError:
+        raise KeyError(f'Environment variable {key_name} is not set') from None
 
 
 def format_prompt(X: str, prompt: str, context: t.Optional[t.List[str]] = None) -> str:

--- a/test/integration/ext/anthropic/model.py
+++ b/test/integration/ext/anthropic/model.py
@@ -1,0 +1,58 @@
+import pytest
+import vcr
+
+from superduperdb.ext.anthropic import AnthropicCompletions
+
+CASSETTE_DIR = 'test/integration/ext/anthropic/cassettes'
+
+
+@pytest.mark.skip(reason="API is not publically available yet")
+@vcr.use_cassette(
+    f'{CASSETTE_DIR}/test_completions.yaml',
+    filter_headers=['authorization'],
+)
+def test_completions():
+    e = AnthropicCompletions(model='claude-2', prompt='Hello, {context}')
+    resp = e.predict('', one=True, context=['world!'])
+
+    assert isinstance(resp, str)
+
+
+@pytest.mark.skip(reason="API is not publically available yet")
+@vcr.use_cassette(
+    f'{CASSETTE_DIR}/test_batch_completions.yaml',
+    filter_headers=['authorization'],
+)
+def test_batch_completions():
+    e = AnthropicCompletions(model='claude-2')
+    resp = e.predict(['Hello, world!'], one=False)
+
+    assert isinstance(resp, list)
+    assert isinstance(resp[0], str)
+
+
+@pytest.mark.skip(reason="API is not publically available yet")
+@vcr.use_cassette(
+    f'{CASSETTE_DIR}/test_completions_async.yaml',
+    filter_headers=['authorization'],
+)
+@pytest.mark.asyncio
+async def test_completions_async():
+    e = AnthropicCompletions(model='claude-2', prompt='Hello, {context}')
+    resp = await e.apredict('', one=True, context=['world!'])
+
+    assert isinstance(resp, str)
+
+
+@pytest.mark.skip(reason="API is not publically available yet")
+@vcr.use_cassette(
+    f'{CASSETTE_DIR}/test_batch_completions_async.yaml',
+    filter_headers=['authorization'],
+)
+@pytest.mark.asyncio
+async def test_batch_completions_async():
+    e = AnthropicCompletions(model='claude-2')
+    resp = await e.apredict(['Hello, world!'], one=False)
+
+    assert isinstance(resp, list)
+    assert isinstance(resp[0], str)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This PR adds the Anthropic `Completions` endpoint (there is currently no embedding endpoint). There is no publically available API service at this time, and so the tests are currently set to skip. Once the API becomes publically available we can re-activate this functionality (using `pyvcr` as a test mock).


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#837 


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?


## Additional Notes or Comments
