### PR TITLE
Add test-and-fix target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ test: test-containers
 
 .PHONY: fix-and-test
 fix-and-test: test-containers
+	isort $(DIRECTORIES)
+	black $(DIRECTORIES)
+	ruff check --fix $(DIRECTORIES)
+	mypy superduperdb
+	pytest $(PYTEST_ARGUMENTS)
+	interrogate superduperdb
+
+.PHONY: test-and-fix
+test-and-fix: test-containers
 	mypy superduperdb
 	pytest $(PYTEST_ARGUMENTS)
 	isort $(DIRECTORIES)


### PR DESCRIPTION
## Additional Notes or Comments

I realized that the `fix-and-test` target was actually `test-and-fix`, and now I've experimented with it for a few days, I use both cases, but perhaps this is extravagant.  