### PR TITLE
Improve link checker to compensate for relative paths

### DIFF
--- a/.github/workflows/test-deps-and-links.yml
+++ b/.github/workflows/test-deps-and-links.yml
@@ -75,4 +75,20 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@master
+      - name: Create configuration for handling relative paths
+        # regex validation: https://regex101.com/r/L2M2wa/1
+        run: |
+          cat <<EOF > mlc_config.json
+          {
+            "replacementPatterns": [
+              {
+              "pattern": "^[./]",
+              "replacement": "{{BASEURL}}/"
+              }
+              ]
+          }
+          EOF
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: 'mlc_config.json'
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

The first implementation of the broken link [checker](https://github.com/SuperDuperDB/superduperdb/pull/932) did not handle relative paths and reported several false positives.

This patch fixes the issue with relative paths ( `./filename` and `/filename` ) but cannot handle files without any prefix (e.g., filename). Albeit this format conventionally implies a `./` prefix, it's tricky to come up with a regex that can handle it. So it's easier (and clearer) to change these files to the typical prefixed format `./filename`.

## Related Issues

#910 



## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
