### PR TITLE
Shorten DB._create_children

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,5 @@ test/sleep.json
 
 # editors
 .vscode
+
+/tmp


### PR DESCRIPTION
Closes https://github.com/SuperDuperDB/superduperdb/issues/985

I've removed a code branch that wasn't being exercised by the tests at all, and all subclasses of DB don't use that option regardless of tests. This might be shortening a bit too much :wink: But if that case really needs to be handled, then I think testing it is more important than refactoring, and I don't know what that test would look like.

## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?