### PR TITLE
Add support python 3.12

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]  # TODO: add "windows-latest", "macos-latest" when Docker removed
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -92,7 +92,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r .github/ci-pinned-requirements/dev.txt
+        run: |
+          pip install -U pip
+          pip install -r .github/ci-pinned-requirements/dev.txt
 
       - name: Basic health check
         run: |

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          pip install -U pip
+          pip install pip 'setuptools>=64' --upgrade
           pip install -r .github/ci-pinned-requirements/dev.txt
 
       - name: Basic health check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

python 3.12 released at Python 3.12 was released on October 2, 2023 and GitHub action support it too,
https://docs.python.org/3.12/whatsnew/3.12.html#:~:text=This%20article%20explains%20the%20new,full%20details%2C%20see%20the%20changelog.

maybe we should add test for python 3.12 and also change our package metadata to fit python 3.12


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

fix: #1058


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
