### PR TITLE
revert old ci functions into makefile

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Lint and type-check
         run: |
-          make lint
+          make lint-and-type-check
 
       - name: test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ mongo_init: ## Initialize a local MongoDB setup
 mongo_shutdown: ## Terminate the local MongoDB setup
 	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
 
-test: mongo_init ## Alias to test-containers
+test: mongo_init ## Perform unit testing
 	pytest $(PYTEST_ARGUMENTS)
 
-clean-test: mongo_shutdown	## Alias to clean-test-containers
+clean-test: mongo_shutdown	## Clean-up unit testing environment
 
 fix-and-test: mongo_init ## Lint before testing
 	isort $(DIRECTORIES)

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,18 @@ docker-push: ## Push the latest SuperDuperDB image
 
 
 
-##@ DevOps Functions
+##@ CI Functions
 
-lint: ## Lint your local copy
-	mypy superduperdb
-	black --check $(DIRECTORIES)
-	ruff check $(DIRECTORIES)
-	interrogate superduperdb
+mongo_init: ## Initialize a local MongoDB setup
+	docker compose -f test/material/docker-compose.yml up mongodb mongo-init -d $(COMPOSE_ARGUMENTS)
+
+mongo_shutdown: ## Terminate the local MongoDB setup
+	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
+
+test: mongo_init ## Alias to test-containers
+	pytest $(PYTEST_ARGUMENTS)
+
+clean-test: mongo_shutdown	## Alias to clean-test-containers
 
 fix-and-test: mongo_init ## Lint before testing
 	isort $(DIRECTORIES)
@@ -84,6 +89,22 @@ fix-and-test: mongo_init ## Lint before testing
 	mypy superduperdb
 	pytest $(PYTEST_ARGUMENTS)
 	interrogate superduperdb
+
+test-and-fix: mongo_init ## Test before linting.
+	mypy superduperdb
+	pytest $(PYTEST_ARGUMENTS)
+	black $(DIRECTORIES)
+	ruff check --fix $(DIRECTORIES)
+	interrogate superduperdb
+
+lint-and-type-check: ## Lint your code
+	mypy superduperdb
+	black --check $(DIRECTORIES)
+	ruff check $(DIRECTORIES)
+	interrogate superduperdb
+
+
+##@ Demo Environment
 
 test_pr:  ## Run PR into a testenv (make test_pr PR_NUMBER=555)
 	# clone only the latest of all branches
@@ -96,14 +117,6 @@ test_pr:  ## Run PR into a testenv (make test_pr PR_NUMBER=555)
 	docker run -p 8888:8888 -v /tmp/superduperdb_pr_$(PR_NUMBER):/home/superduper/pr_$(PR_NUMBER) superduperdb/superduperdb:latest
 	# todo remove temporary directory
 
-
-##@ Demo Environment
-
-mongo_init: ## Initialize a local MongoDB setup
-	docker compose -f test/material/docker-compose.yml up mongodb mongo-init -d $(COMPOSE_ARGUMENTS)
-
-mongo_shutdown: ## Terminate the local MongoDB setup
-	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
 
 demo-run: ## Run a SuperDuperDB demo locally
 	@echo "===> Run SuperDuperDB Locally <==="


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->

Revert old functions to Makefile.

Functions:
* test
* clean_test
* fix-and-test
* test-and-fix
* lint-and-type-check

The previous known actions `test-containers` and `clean-test-containers` are renamed to `mongo_init` and `mongo_shutdown` to better reflect their functionality.

## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
