### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Lint and type-check
         run: |
-          make lint
+          make lint-and-type-check
 
       - name: test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ new-release: ## Release a new SuperDuperDB version
 	@sed -ie "s/^__version__ = .*/__version__ = '$(RELEASE_VERSION:v%=%)'/" superduperdb/__init__.py
 	@git add superduperdb/__init__.py
 
+	@echo "** Change deploy/docker-compose/demo to version $(RELEASE_VERSION:v%=%)"
+	sed -ie "s/superduperdb\/superduperdb:.*/superduperdb\/superduperdb:$(RELEASE_VERSION:v%=%)/" deploy/docker-compose/demo.yaml
+	@git add deploy/docker-compose/demo
+
 	@echo "** Commit Bump Version and Tags"
 	@git add VERSION
 	@git commit -m "Bump Version $(RELEASE_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ mongo_init: ## Initialize a local MongoDB setup
 mongo_shutdown: ## Terminate the local MongoDB setup
 	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
 
-test: mongo_init ## Alias to test-containers
+test: mongo_init ## Perform unit testing
 	pytest $(PYTEST_ARGUMENTS)
 
-clean-test: mongo_shutdown	## Alias to clean-test-containers
+clean-test: mongo_shutdown	## Clean-up unit testing environment
 
 fix-and-test: mongo_init ## Lint before testing
 	isort $(DIRECTORIES)

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,6 @@ help: ## Display this help
 # The general flow is VERSION -> make new-release -> GITHUB_ACTIONS -> {make docker_push, ...}
 RELEASE_VERSION=$(shell cat VERSION)
 
-# All these variables are populated after the pushed tag from action "new-release".
-TAG_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
-TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
-COMMIT := $(shell git rev-parse --short HEAD)
-DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
-VERSION := $(TAG:v%=%)
-
 
 ##@ Release Management
 
@@ -50,7 +43,7 @@ new-release: ## Release a new SuperDuperDB version
 
 	@echo "** Commit Bump Version and Tags"
 	@git add VERSION
-	@git commit -m "Bump Version $(RELEASE_VERSION)"
+	@git commit -m "Bump Version $(RELEASE_VERSION:v%=%)"
 	@git tag ${RELEASE_VERSION}
 
 	@echo "** Push release-${RELEASE_VERSION}"
@@ -58,15 +51,15 @@ new-release: ## Release a new SuperDuperDB version
 
 
 docker-build: ## Build SuperDuperDB images
-	@echo "===> Build SuperDuperDB:${VERSION} Container <==="
-	docker build ./deploy/images/superduperdb  -t superduperdb/superduperdb:${VERSION}  --progress=plain --no-cache
+	@echo "===> Build SuperDuperDB:$(RELEASE_VERSION:v%=%) Container <==="
+	docker build ./deploy/images/superduperdb  -t superduperdb/superduperdb:$(RELEASE_VERSION:v%=%)  --progress=plain --no-cache
 
 docker-push: ## Push the latest SuperDuperDB image
-	@echo "===> Set SuperDuperDB:${VERSION} as the latest <==="
-	docker tag superduperdb/superduperdb:${VERSION} superduperdb/superduperdb:latest
+	@echo "===> Set SuperDuperDB:$(RELEASE_VERSION:v%=%) as the latest <==="
+	docker tag superduperdb/superduperdb:$(RELEASE_VERSION:v%=%) superduperdb/superduperdb:latest
 
-	@echo "===> Release SuperDuperDB:${VERSION} Container <==="
-	docker push superduperdb/superduperdb:${VERSION}
+	@echo "===> Release SuperDuperDB:$(RELEASE_VERSION:v%=%) Container <==="
+	docker push superduperdb/superduperdb:$(RELEASE_VERSION:v%=%)
 
 	@echo "===> Release SuperDuperDB:latest Container <==="
 	docker push superduperdb/superduperdb:latest

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,18 @@ docker-push: ## Push the latest SuperDuperDB image
 
 
 
-##@ DevOps Functions
+##@ CI Functions
 
-lint: ## Lint your local copy
-	mypy superduperdb
-	black --check $(DIRECTORIES)
-	ruff check $(DIRECTORIES)
-	interrogate superduperdb
+mongo_init: ## Initialize a local MongoDB setup
+	docker compose -f test/material/docker-compose.yml up mongodb mongo-init -d $(COMPOSE_ARGUMENTS)
+
+mongo_shutdown: ## Terminate the local MongoDB setup
+	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
+
+test: mongo_init ## Alias to test-containers
+	pytest $(PYTEST_ARGUMENTS)
+
+clean-test: mongo_shutdown	## Alias to clean-test-containers
 
 fix-and-test: mongo_init ## Lint before testing
 	isort $(DIRECTORIES)
@@ -84,6 +89,22 @@ fix-and-test: mongo_init ## Lint before testing
 	mypy superduperdb
 	pytest $(PYTEST_ARGUMENTS)
 	interrogate superduperdb
+
+test-and-fix: mongo_init ## Test before linting.
+	mypy superduperdb
+	pytest $(PYTEST_ARGUMENTS)
+	black $(DIRECTORIES)
+	ruff check --fix $(DIRECTORIES)
+	interrogate superduperdb
+
+lint-and-type-check: ## Lint your code
+	mypy superduperdb
+	black --check $(DIRECTORIES)
+	ruff check $(DIRECTORIES)
+	interrogate superduperdb
+
+
+##@ Demo Environment
 
 test_pr:  ## Run PR into a testenv (make test_pr PR_NUMBER=555)
 	# clone only the latest of all branches
@@ -96,14 +117,6 @@ test_pr:  ## Run PR into a testenv (make test_pr PR_NUMBER=555)
 	docker run -p 8888:8888 -v /tmp/superduperdb_pr_$(PR_NUMBER):/home/superduper/pr_$(PR_NUMBER) superduperdb/superduperdb:latest
 	# todo remove temporary directory
 
-
-##@ Demo Environment
-
-mongo_init: ## Initialize a local MongoDB setup
-	docker compose -f test/material/docker-compose.yml up mongodb mongo-init -d $(COMPOSE_ARGUMENTS)
-
-mongo_shutdown: ## Terminate the local MongoDB setup
-	docker compose -f test/material/docker-compose.yml down $(COMPOSE_ARGUMENTS)
 
 demo-run: ## Run a SuperDuperDB demo locally
 	@echo "===> Run SuperDuperDB Locally <==="

--- a/deploy/images/superduperdb/Dockerfile
+++ b/deploy/images/superduperdb/Dockerfile
@@ -51,7 +51,7 @@ COPY --chown=superduper ./apputils-extension/themes.jupyterlab-settings ${HOME}/
 
 # Install Jupyter Extension
 # ---------------
-#RUN export PATH=${HOME}/.local/bin:$PATH && \
+RUN export PATH=${HOME}/.local/bin:$PATH #&& \
 #    pip install 'jupyterlab>=4.0.0,<5.0.0a0' jupyterlab-lsp &&\
 #    pip install 'python-lsp-server[all]'
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

Revert old functions to Makefile.

Functions:

    test
    clean_test
    fix-and-test
    test-and-fix
    lint-and-type-check

The previous known actions test-containers and clean-test-containers are renamed to mongo_init and mongo_shutdown to better reflect their functionality.

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
