### PR TITLE
Fix passing chunk-size onwards

### DIFF
--- a/test/unittest/test_quality.py
+++ b/test/unittest/test_quality.py
@@ -19,7 +19,7 @@ DEFECTS = {
 ALLOWABLE_DEFECTS = {
     'cast': 12,  # Try to keep this down
     'noqa': 1,  # This should never change
-    'type_ignore': 37,  # This should only ever increase in obscure edge cases
+    'type_ignore': 35,  # This should only ever increase in obscure edge cases
 }
 
 


### PR DESCRIPTION
A bug was blindly introduced in validation in a `mypy` refactor:

Here's the diff which created the bug:

https://github.com/SuperDuperDB/superduperdb/commit/d7077d330c893a71da72a164b855d4f54c8ba9ce

This points to deficiencies in our test-suite which should be removed ASAP.