### PR TITLE
Fix adding scores to aggregate pipelines in Atlas vector-search

### DIFF
--- a/superduperdb/base/cursor.py
+++ b/superduperdb/base/cursor.py
@@ -88,7 +88,7 @@ class SuperDuperCursor:
     def __next__(self):
         r = self.cursor_next()
         if self.scores is not None:
-            r['_score'] = self.scores[str(r[self.id_field])]
+            r['score'] = self.scores[str(r[self.id_field])]
         if self.features is not None and self.features:
             r = self.add_features(r, features=self.features)
         if CFG.downloads.hybrid:

--- a/test/integration/test_atlas.py
+++ b/test/integration/test_atlas.py
@@ -76,4 +76,4 @@ def test_use_atlas_vector_search(atlas_search_config):
         print(r)
         it += 1
 
-    assert it == 4
+    assert it == 5


### PR DESCRIPTION
The original pull request had several issues which are resolved here:

- Scores only supported by new `$vectorSearch` operator
- `$project` to scores only works if there is a projection specified in `self.args[1:]`
- `$addFields` necessary to add scores actively (otherwise omitted)