### PR TITLE
add missing dependency for opencv

### DIFF
--- a/deploy/images/superduperdb/Dockerfile
+++ b/deploy/images/superduperdb/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update \
         wget curl unzip git \
         # DevOps
         vim procps make \
+        # Required by OpenCV
+        libglib2.0-0 libgl1-mesa-glx \
    # Purge apt cache
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

Add missing `libglib2.0-0 libgl1-mesa-glx` dependencies required to properly use opencv in the books

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
