### PR TITLE
Remove `isort` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,6 @@ test: mongo_init ## Execute unit testing
 clean-test: mongo_shutdown	##  Clean up the unit testing environment
 
 fix-and-test: mongo_init ##  Lint the code before testing
-	# Sort mports
-	isort $(DIRECTORIES)
 	# Code formatting
 	black $(DIRECTORIES)
 	# Linter and code formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ quality = [
     "types-tqdm>=4.65.0.1",
     "monkeytype",
     "boto3-stubs>=1.26.154",
-    # Linting
-    "isort>=3.8.1",
     "black>=23.3",
     "interrogate>=1.5.0",
     "ruff>=0.0.267",


### PR DESCRIPTION
Looks like `isort` was removed as a dependency since `ruff` was used with isort config, but somehow it got back in the dependencies.


## Description

Removes `isort` from dependencies and Makefile.


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
