### PR TITLE
e2e testing for mongo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ integration-testing: ## Execute integration testing
 	cd ./test/material/testenv/; ./wait_ready.sh
 
 	# Make sure endpoints are discoverable
-	#getent hosts mongodb scheduler
+	getent hosts mongodb #scheduler
 
 	# Run the test
 	pytest $(PYTEST_ARGUMENTS) ./test/integration

--- a/superduperdb/base/build.py
+++ b/superduperdb/base/build.py
@@ -72,7 +72,6 @@ def build_datalayer(cfg=None, **kwargs) -> Datalayer:
         logging.error("Error initializing to DataBackend Client:", str(e))
         sys.exit(1)
 
-
     # Build a Datalayer object with the specified components.
     db = Datalayer(
         databackend=databackend,

--- a/superduperdb/base/build.py
+++ b/superduperdb/base/build.py
@@ -1,6 +1,12 @@
 import re
+import sys
+
+import ibis
+import mongomock
+import pymongo
 
 import superduperdb as s
+from superduperdb import logging
 from superduperdb.backends.base.backends import data_backends, metadata_stores
 from superduperdb.backends.filesystem.artifacts import FileSystemArtifactStore
 from superduperdb.backends.mongodb.artifacts import MongoArtifactStore
@@ -26,37 +32,48 @@ def build_artifact_store(cfg):
 
 def build_datalayer(cfg=None, **kwargs) -> Datalayer:
     """
-    Build db as per ``db = superduper(db)`` from configuration.
+    Build a Datalayer object as per ``db = superduper(db)`` from configuration.
 
-    :param cfg: configuration to use. If None, use ``superduperdb.CFG``.
+    :param cfg: Configuration to use. If None, use ``superduperdb.CFG``.
     """
+
+    # Use the provided configuration or fall back to the default configuration.
     cfg = cfg or s.CFG
 
+    # Update configuration with keyword arguments.
     for k, v in kwargs.items():
         setattr(cfg, k, v)
 
+    # Helper function to build a data backend based on the URI.
     def build(uri, mapping):
         if re.match('^mongodb:\/\/|^mongodb\+srv:\/\/', uri) is not None:
             name = uri.split('/')[-1]
-            import pymongo
+            conn = pymongo.MongoClient(
+                uri,
+                serverSelectionTimeoutMS=5000,
+            )
 
-            uri = '/'.join(uri.split('/')[:-1])
-            conn = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000)
             return mapping['mongodb'](conn, name)
         elif uri.startswith('mongomock://'):
             name = uri.split('/')[-1]
-            import mongomock
-
             conn = mongomock.MongoClient()
             return mapping['mongodb'](conn, name)
         else:
-            import ibis
-
+            name = uri.split('//')[0]
             conn = ibis.connect(uri)
-            return mapping['ibis'](conn, uri.split('//')[0])
+            return mapping['ibis'](conn, name)
 
-    databackend = build(cfg.data_backend, data_backends)
+    # Connect to data backend.
+    try:
+        databackend = build(cfg.data_backend, data_backends)
+        logging.success("Initializing DataBackend Client: ", databackend.conn)
+    except Exception as e:
+        # Exit quickly if a connection fails.
+        logging.error("Error initializing to DataBackend Client:", str(e))
+        sys.exit(1)
 
+
+    # Build a Datalayer object with the specified components.
     db = Datalayer(
         databackend=databackend,
         metadata=(

--- a/superduperdb/base/config.py
+++ b/superduperdb/base/config.py
@@ -142,7 +142,7 @@ class Config(JSONable):
     def self_hosted_vector_search(self) -> bool:
         return re.split('://|\+', self.data_backend)[0] == self.vector_search
 
-    data_backend: str = 'mongodb://localhost:27018'
+    data_backend: str = 'mongodb://superduper:superduper@mongodb/test_db'
 
     #: The configuration for the vector search
     vector_search: 'str' = 'in_memory'  # "in_memory" / "lance"

--- a/superduperdb/base/config.py
+++ b/superduperdb/base/config.py
@@ -142,7 +142,7 @@ class Config(JSONable):
     def self_hosted_vector_search(self) -> bool:
         return re.split('://|\+', self.data_backend)[0] == self.vector_search
 
-    data_backend: str = 'mongodb://superduper:superduper@mongodb/test_db'
+    data_backend: str = 'mongodb://superduper:superduper@mongodb:27017/test_db'
 
     #: The configuration for the vector search
     vector_search: 'str' = 'in_memory'  # "in_memory" / "lance"

--- a/superduperdb/base/datalayer.py
+++ b/superduperdb/base/datalayer.py
@@ -114,7 +114,7 @@ class Datalayer:
         assert isinstance(clt.identifier, str), 'clt.identifier must be a string'
 
         if self.cdc.running:
-            # In this case loading has already happened on disk via CDC mechanism
+            # In this case, loading has already happened on disk via CDC mechanism
             return vector_comparison
 
         if backfill or s.CFG.mode != 'production':
@@ -296,7 +296,7 @@ class Datalayer:
         """
         Apply model to input.
 
-        :param model: model identifier
+        :param model_name: model identifier
         :param input: input to be passed to the model.
                       Must be possible to encode with registered encoders
         :param context_select: select query object to provide context

--- a/superduperdb/ext/openai/model.py
+++ b/superduperdb/ext/openai/model.py
@@ -59,9 +59,6 @@ class OpenAI(Component, PredictMixin):
         return []
 
     def __post_init__(self):
-        if 'OPENAI_API_KEY' not in os.environ:
-            raise ValueError('OPENAI_API_KEY not set')
-
         # dall-e is not currently included in list returned by OpenAI model endpoint
         if self.model not in (mo := _available_models()) and self.model not in (
             'dall-e'
@@ -73,6 +70,9 @@ class OpenAI(Component, PredictMixin):
 
         self.syncClient = SyncOpenAI()
         self.asyncClient = AsyncOpenAI()
+
+        if 'OPENAI_API_KEY' not in os.environ:
+            raise ValueError('OPENAI_API_KEY not set')
 
 
 @dc.dataclass

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,6 @@
 import inspect
 import os
 import time
-import uuid
 from threading import Lock
 from typing import Iterator
 
@@ -69,12 +68,8 @@ def test_db(monkeypatch, request) -> Iterator[Datalayer]:
     from superduperdb import CFG
     from superduperdb.base.build import build_datalayer
 
-    # use the below decorator to set the db name, if not using random db_name
-    # `@pytest.mark.parametrize('test_db', [db_name], indirect=True)`
-    db_name = getattr(request, 'param', uuid.uuid4().hex)
-    # data_backend = f'mongodb://superduper:superduper@mongodb:27017/{db_name}'
-
-    data_backend = 'mongodb://superduper:superduper@mongodb:27017/test_db'
+    db_name = "test_db"
+    data_backend = f'mongodb://superduper:superduper@mongodb:27017/{db_name}'
 
     monkeypatch.setattr(CFG, 'data_backend', data_backend)
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,5 +1,4 @@
 import random
-import uuid
 
 import numpy as np
 import pytest
@@ -112,10 +111,9 @@ def fake_updates(database_with_default_encoders_and_model):
 
 @pytest.fixture
 def local_dask_client(monkeypatch, request):
-    db_name = getattr(request, 'param', uuid.uuid4().hex)
-    data_backend = (
-        f'mongodb://testmongodbuser:testmongodbpassword@localhost:27018/{db_name}'
-    )
+    db_name = "test_db"
+    data_backend = f'mongodb://superduper:superduper@mongodb:27017/{db_name}'
+
     monkeypatch.setenv('SUPERDUPERDB_DATA_BACKEND', data_backend)
     client = dask_client(CFG.cluster, local=True)
     yield client

--- a/test/material/testenv/README.md
+++ b/test/material/testenv/README.md
@@ -1,0 +1,23 @@
+# Run SuperDuperDB using Docker-Compose
+
+#### Build and run your app with Compose
+```shell
+ docker-compose -f demo.yaml up 
+```
+
+### Available users:
+
+`superduper:superduper` on `test_db` database
+
+```shell
+mongosh "mongodb://superduper:superduper@mongodb:27017/test_db"
+```
+
+Have in mind that `docker-compose` with source the `default credentials` from `.env` file.
+
+#### Access Jupyter
+Jupyter is now accessible by your browser:
+
+```shell
+http://localhost:8888/lab
+```

--- a/test/material/testenv/docker-compose.yaml
+++ b/test/material/testenv/docker-compose.yaml
@@ -1,21 +1,89 @@
 version: "3.9"
 services:
+  # Resolv container hostnames
+  # ------------------------------
+  host-mapper:
+    image: dvdarias/docker-hoster
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock
+      - /etc/hosts:/tmp/hosts
+
+  # MongoDB Datastore
+  # ------------------------------
   mongodb:
     image: mongo:6
-    container_name: sddb-mongodb
-    restart: always
-    # use ["x", "y", ...] syntax for cross-platform compatibility
-    command : ["/bin/sh", "-c", "mongod --replSet rs0 --port 27018 --bind_ip 0.0.0.0 --dbpath /data/db/"]
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: testmongodbuser
-      MONGO_INITDB_ROOT_PASSWORD: testmongodbpassword
+    hostname: mongodb
     ports:
-      - "27018:27018"
+      - "27017:27017"
+    command : ["/bin/sh", "-c", "mongod --replSet rs0 --port 27017 --bind_ip 0.0.0.0 --dbpath /data/db/"]
 
   mongo-init:
     image: mongo:6
     depends_on:
       - mongodb
-    command: sh -c "/scripts/mongo-init.sh"
     volumes:
       - ./mongo-init.sh:/scripts/mongo-init.sh
+    env_file: # Read From
+    - users.env
+    command: sh -c "/scripts/mongo-init.sh"
+
+#  # Dask Parallel Computation
+#  # ------------------------------
+#  dask-scheduler:
+#    build: # Build the latest SuperDuperDB code
+#      context: ../../../. # Build from project's root
+#      dockerfile: ./images/superduperdb/Dockerfile
+#    hostname: scheduler
+#    ports:
+#      - "8786:8786" # Peer communication
+#      - "8787:8787" # HTTP Dashboard
+#    volumes:
+#        - ../../../:/app # mount the root path
+#    command:
+#      - /bin/sh
+#      - -c
+#      - |
+#        cd /app
+#
+#        # Basic stuff needed for pickling.
+#        # No complex dependencies
+#        pip install .
+#        dask scheduler
+#
+#
+#  dask-worker:
+#    depends_on:
+#      -   dask-scheduler
+#    build: # Build the latest SuperDuperDB code
+#      context: ../../../. # Build from project's root
+#      dockerfile: ./images/superduperdb/Dockerfile
+#    volumes:
+#        - ../../../:/app # mount the root path
+##    environment:
+##        - SUPERDUPERDB_DATA_BACKEND = 'mongodb://mongodb:27017'
+#    command:
+#      - /bin/sh
+#      - -c
+#      - |
+#        cd /app
+#
+#        # Require all computational dependencies
+#        pip install .[torch,apis,docs,quality,testing]
+#        dask worker "tcp://scheduler:8786"
+#    deploy:
+#      replicas: 1
+
+
+  # SuperDuperDB Notebooks
+  # ------------------------------
+  #superduperdb:
+  #  depends_on:
+  #    - mongodb
+  #    - dask-scheduler
+  #  image: superduperdb/demo:0.0.15
+  #  ports:
+  #    - "8888:8888"
+  #  command: ["jupyter", "lab", "--ip='*'", "--LabApp.token=''"]
+  #  environment:
+  #      DASK_URI: "tcp://dask-scheduler:8786"
+  #      MONGODB_URI: "mongodb://${SDDB_USER}:${SDDB_PASS}@mongodb"

--- a/test/material/testenv/mongo-init.sh
+++ b/test/material/testenv/mongo-init.sh
@@ -1,37 +1,55 @@
-MONGO_INITDB_USERNAME=testmongodbuser
-MONGO_INITDB_PASSWORD=testmongodbpassword
-MONGO_PORT=27018
+#!/bin/bash
 
-init_replicaset_cmd="\
-	rs.initiate( \
-	{ \
-		_id:\"rs0\", \
-		version: 1, \
-		members: [ \
-		{ _id: 0, host : \"localhost:$MONGO_PORT\" }] \
-	} \
-	); \
-	rs.status(); \
-"
+set -eu
 
-create_user_cmd="\
-    db.getSiblingDB('admin').createUser( \
-        { \
-            user: \"$MONGO_INITDB_USERNAME\", \
-            pwd: \"$MONGO_INITDB_PASSWORD\", \
-            roles: [ { role: \"root\", db: \"admin\" } ] \
-         } \
-    ); \
-    rs.status(); \
-"
 # replicate set initiate
 echo "Checking mongo container..."
-until mongosh --host sddb-mongodb --port $MONGO_PORT --eval "print(\"waited for connection\")"
+until mongosh --host mongodb  --eval "print(\"waited for connection\")"
 do
     sleep 1
 done
 
 echo "Initializing replicaset..."
-mongosh --host sddb-mongodb --port $MONGO_PORT --eval "$init_replicaset_cmd"
+mongosh --host mongodb  <<EOF
+    rs.initiate(
+      {
+          _id: "rs0",
+          version: 1,
+          members: [
+            { _id: 0, host: "mongodb:27017"}
+          ]
+      }
+    )
+    rs.status()
+EOF
 
-mongosh --host sddb-mongodb --port $MONGO_PORT  --eval "$create_user_cmd"
+
+echo "Creating admin user: root@root/admin"
+mongosh --host mongodb  <<EOF
+    db.getSiblingDB('admin').createUser(
+        {
+            user: "root",
+            pwd: "root",
+            roles: [ { role: "root", db: "admin" } ]
+         }
+    )
+
+    rs.status()
+EOF
+
+echo "Creating normal user: superduper:superduper/test_db"
+mongosh --host mongodb  <<EOF
+  use ${SDDB_DATABASE}
+  db.createUser(
+    {
+      user: "${SDDB_USER}",
+      pwd: "${SDDB_PASS}",
+      roles: [ { role: "dbOwner", db: "${SDDB_DATABASE}" } ]
+    }
+  )
+EOF
+
+echo "Confirm everything works properly"
+echo "---------------------------------------"
+mongosh --eval 'rs.status()' "mongodb://${SDDB_USER}:${SDDB_PASS}@mongodb:27017/${SDDB_DATABASE}"
+echo "---------------------------------------"

--- a/test/material/testenv/users.env
+++ b/test/material/testenv/users.env
@@ -1,0 +1,4 @@
+# Custom user for SuperDuper
+SDDB_USER=superduper
+SDDB_PASS=superduper
+SDDB_DATABASE=test_db


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

Add end-to-end testing for mongo.

The `test_cdc` is falling.
This is probably due to a false assumption that the database is being reset on every iteration. However, this is not the case for integration testing, and the `test_index` is increasingly populated, resulting in failing assertions.

For instance:

```
>       raise Exception(exc_msg)
E       Exception: assert 55 == 1
E        +  where 55 = len(<superduperdb.vector_search.interface.FastVectorSearcher object at 0x7f1bba7bd650>)

test/integration/test_cdc.py:93: Exception
====================================================================== short test summary info =======================================================================
FAILED test/integration/test_cdc.py::test_vector_database_sync - Exception: assert 55 == 1
========================================================================= 1 failed in 1.67s ==========================================================================

```


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
