### PR TITLE
[DOC]: Added missing word in the blog

### DIFF
--- a/docs/hr/blog/v1/releasingv1.md
+++ b/docs/hr/blog/v1/releasingv1.md
@@ -82,7 +82,7 @@ SuperDuperDB provides a unified environment for building, shipping, and managing
 
 ### Open source
 
-We AI software should be open-sourced to the community. Truly open-source tools are the only sure way for developers to protect their stacks from vunerable dependencies.
+We believe AI software should be open-sourced to the community. Truly open-source tools are the only sure way for developers to protect their stacks from vunerable dependencies.
 
 With SuperDuperDB, we are excited to be part of a thriving open-source AI ecosystem. There is a wealth of open-source AI software and models available, including `transformers` from Hugging Face, `llama-2.0` and other LLMs that can compete with OpenAI's closed source models, computer vision models in PyTorch, and a plethora of new open-source tools and models emerging from GitHub.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

This PR intends to add a missing word in the   [blog](https://github.com/SuperDuperDB/superduperdb/blob/main/docs/hr/blog/v1/releasingv1.md) at this [line](https://github.com/SuperDuperDB/superduperdb/blob/6104fb81c3470fa74a4c87c1c9c91c7ff8a68258/docs/hr/blog/v1/releasingv1.md?plain=1#L85)

## Changes

This PR adds the word `believe` to change the documentation from 
`We AI software should be open-sourced to the community` to `We believe AI software should be open-sourced to the community`


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
Since this PR addresses a fix only in the documentation, the idea was that maybe the above checklist was not necessary to mark. In case it needs to be followed through, let me know by leaving a comment 