### PR TITLE
add mysql to db integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For more information about SuperDuperDB and why we believe it is much needed, [r
 **Transform your existing database into a Python-only AI development and deployment stack with one command:**
 
 ```
-db = superduper('mongodb|postgres|sqlite|duckdb|snowflake://<your-db-uri>')
+db = superduper('mongodb|postgres|mysql|sqlite|duckdb|snowflake://<your-db-uri>')
 ```
 
 ## Supported AI Frameworks and Models (*more coming soon*):


### PR DESCRIPTION
MySQL is one of the most popular DB choices and should be in the DB connection string.

## Description

When people land on the GitHub repo, they first browse README.md. I added MySQL in the DB connection example so that people are assured it supports MySQL.