### PR TITLE
Feature/additional parameters options predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Simplify the testing of SQL databases using containerized databases
 - Integrate Monitoring(cadvisor/Prometheus) and Logging (promtail/Loki) with Grafana, in the `testenv`
+- Add `QueryModel` and `SequentialModel` to make chaining searches and models easier.
+- Add `insert_to=<table-or-collection>` to `.predict` to allow single predictions to be saved.
 
 #### Bug Fixes
 

--- a/superduperdb/backends/base/query.py
+++ b/superduperdb/backends/base/query.py
@@ -42,7 +42,7 @@ class Select(Serializable, ABC):
     def model_update(
         self,
         db,
-        ids: t.Sequence[str],
+        ids: t.List[str],
         key: str,
         model: str,
         version: int,
@@ -534,12 +534,12 @@ class Like(Serializable):
     """
     Base class for all like (vector-search) queries.
 
-    :param r: The vector to search for
+    :param r: The item to be converted to a vector, to search with.
     :param vector_index: The vector index to use
     :param n: The number of results to return
     """
 
-    r: Document
+    r: t.Union[t.Dict, Document]
     vector_index: str
     n: int = 10
 
@@ -572,6 +572,24 @@ class TableOrCollection(Serializable, ABC):
         return self.query_components.get(name, QueryComponent)(
             name=name, type=QueryType.ATTR
         )
+
+    @abstractmethod
+    def model_update(
+        self,
+        db,
+        ids: t.List[t.Any],
+        key: str,
+        model: str,
+        version: int,
+        outputs: t.Sequence[t.Any],
+        flatten: bool = False,
+        **kwargs,
+    ):
+        pass
+
+    @abstractmethod
+    def insert(self, documents: t.Sequence[Document], **kwargs) -> Insert:
+        pass
 
     @abstractmethod
     def _get_query(

--- a/superduperdb/backends/ibis/query.py
+++ b/superduperdb/backends/ibis/query.py
@@ -266,7 +266,7 @@ class IbisCompoundSelect(CompoundSelect):
     def model_update(  # type: ignore[override]
         self,
         db,
-        ids: t.Sequence[t.Any],
+        ids: t.List[t.Any],
         key: str,
         model: str,
         version: int,
@@ -468,7 +468,7 @@ class IbisQueryLinker(QueryLinker, _LogicalExprMixin):
                     if version is not None
                     else Variable(
                         get_output_table_name(model, '{version}'),
-                        lambda db, value: value.format(
+                        lambda db, value, kwargs: value.format(
                             version=db.show('model', model)[-1]
                         ),
                     )
@@ -482,7 +482,7 @@ class IbisQueryLinker(QueryLinker, _LogicalExprMixin):
                         if version is not None
                         else Variable(
                             f'_outputs.{key}.{model}' + '.{version}',
-                            lambda db, value: value.format(
+                            lambda db, value, kwargs: value.format(
                                 version=db.show('model', model)[-1]
                             ),
                         )
@@ -721,6 +721,19 @@ class IbisQueryTable(_ReprMixin, TableOrCollection, Select):
 
     def execute(self, db):
         return db.databackend.conn.table(self.identifier).execute()
+
+    def model_update(
+        self,
+        db,
+        ids: t.List[t.Any],
+        key: str,
+        model: str,
+        version: int,
+        outputs: t.Sequence[t.Any],
+        flatten: bool = False,
+        **kwargs,
+    ):
+        raise NotImplementedError
 
 
 def _compile_item(item, db, tables):

--- a/superduperdb/backends/mongodb/query.py
+++ b/superduperdb/backends/mongodb/query.py
@@ -695,7 +695,8 @@ class Collection(TableOrCollection):
                     if args:
                         second_part.append({"$match": args[0] if args else {}})
                     if args[1:]:
-                        project_args = args[1].update(
+                        project_args = args[1].copy()
+                        project_args.update(
                             {"score": {"$meta": "vectorSearchScore"}}
                         )
                         second_part.append({"$project": project_args})

--- a/superduperdb/base/datalayer.py
+++ b/superduperdb/base/datalayer.py
@@ -654,6 +654,7 @@ class Datalayer:
         info = self.artifact_store.load(info, lazy=True)
 
         m = Component.deserialize(info)
+        m.db = self
         m.on_load(self)
 
         if cm := self.type_id_to_cache_mapping.get(type_id):
@@ -864,6 +865,7 @@ class Datalayer:
         parent: t.Optional[str] = None,
     ):
         jobs = []
+        object.db = self
         object.pre_create(self)
         assert hasattr(object, 'identifier')
         assert hasattr(object, 'version')
@@ -1209,12 +1211,15 @@ class Datalayer:
 
     def select_nearest(
         self,
-        like: Document,
+        like: t.Union[t.Dict, Document],
         vector_index: str,
         ids: t.Optional[t.Sequence[str]] = None,
         outputs: t.Optional[Document] = None,
         n: int = 100,
     ) -> t.Tuple[t.List[str], t.List[float]]:
+        if not isinstance(like, Document):
+            assert isinstance(like, dict)
+            like = Document(like)
         like = self._get_content_for_filter(like)
         vi = self.vector_indices[vector_index]
         if outputs is None:

--- a/superduperdb/base/document.py
+++ b/superduperdb/base/document.py
@@ -40,6 +40,20 @@ class Document:
             return _encode_with_schema(self.content, schema)
         return _encode(self.content)
 
+    @property
+    def variables(self) -> t.List[str]:
+        from superduperdb.base.serializable import _find_variables
+
+        return _find_variables(self.content)
+
+    def set_variables(self, db, **kwargs) -> 'Document':
+        from superduperdb.base.serializable import _replace_variables
+
+        content = _replace_variables(
+            self.content, db, **kwargs
+        )  # replace variables with values
+        return Document(content)
+
     def outputs(self, key: str, model: str, version: t.Optional[int] = None) -> t.Any:
         """
         Get document ouputs on ``key`` from ``model``

--- a/superduperdb/base/serializable.py
+++ b/superduperdb/base/serializable.py
@@ -48,105 +48,81 @@ def _deserialize(r: t.Any, db: None = None) -> t.Any:
     return instance
 
 
-def _serialize(item: t.Any) -> t.Dict[str, t.Any]:
-    def unpack(k, v):
-        attr = getattr(item, k)
-        if isinstance(attr, Serializable):
-            return _serialize(attr)
-
-        if isinstance(attr, (list, tuple)):
-            if isinstance(attr, tuple):
-                v = list(v)
-
-            for i, sc in enumerate(attr):
-                if isinstance(sc, Serializable):
-                    v[i] = _serialize(sc)
-
-        if isinstance(attr, dict):
-            for key, value in attr.items():
-                if isinstance(value, Serializable):
-                    v[key] = _serialize(value)
-        return v
-
-    d = {k: unpack(k, v) for k, v in item.dict().items()}
-
-    from superduperdb.components.component import Component
-
-    to_add = {}
-    if isinstance(item, Component):
-        to_add = {
-            'type_id': item.type_id,
-            'identifier': item.identifier,
-            'version': getattr(item, 'version', None),
+def _serialize(item: t.Any, serialize_variables: bool = True):
+    if isinstance(item, Serializable):
+        sub_dict = {
+            k: _serialize(getattr(item, k), serialize_variables=serialize_variables)
+            for k in item.dict()
         }
+        out = {
+            'cls': item.__class__.__name__,
+            'dict': sub_dict,
+            'module': item.__class__.__module__,
+        }
+        from superduperdb.components.component import Component
 
-    return {
-        'cls': item.__class__.__name__,
-        'dict': d,
-        'module': item.__class__.__module__,
-        **to_add,
-    }
+        if isinstance(item, Component):
+            out.update(
+                {
+                    'type_id': item.type_id,
+                    'identifier': item.identifier,
+                    'version': getattr(
+                        item,
+                        'version',
+                        None,
+                    ),  # type: ignore[dict-item]
+                }
+            )
+        return out
+    if isinstance(item, dict):
+        return {
+            k: _serialize(v, serialize_variables=serialize_variables)
+            for k, v in item.items()
+        }
+    if isinstance(item, (list, tuple)):
+        return [_serialize(x, serialize_variables=serialize_variables) for x in item]
+    if serialize_variables:
+        if isinstance(item, Variable):
+            return {
+                'cls': 'Variable',
+                'dict': {'value': item.value, 'setter_callback': item.setter_callback},
+                'module': 'superduperdb.base.serializable',
+            }
+    return item
 
 
 class VariableError(Exception):
     ...
 
 
-class Variable:
-    """
-    Mechanism for allowing "free variables" in a serializable object.
-    The idea is to allow a variable to be set at runtime, rather than
-    at object creation time.
-
-    :param value: The name of the variable to be set at runtime.
-    """
-
-    def __init__(self, value, setter_callback):
-        self.value = value
-        self.setter_callback = setter_callback
-
-    def __repr__(self) -> str:
-        return '$' + str(self.value)
-
-    def __hash__(self) -> int:
-        return hash(self.value)
-
-    def set(self, db):
-        """
-        Get the intended value from the values of the global variables.
-
-        >>> Variable('number').set(number=1.5, other='test')
-        1.5
-
-        :param db: The datalayer instance.
-        """
-        try:
-            return self.setter_callback(db, self.value)
-        except Exception as e:
-            raise VariableError(
-                f'Could not set variable {self.value} based on {self.setter_callback}'
-            ) from e
-
-
 def _find_variables(r):
+    from .document import Document
+
     if isinstance(r, dict):
         return sum([_find_variables(v) for v in r.values()], [])
     elif isinstance(r, (list, tuple)):
         return sum([_find_variables(v) for v in r], [])
     elif isinstance(r, Variable):
         return [r]
+    elif isinstance(r, Document):
+        return r.variables
     return []
 
 
-def _replace_variables(x, db):
+def _replace_variables(x, db, **kwargs):
+    from .document import Document
+
     if isinstance(x, dict):
         return {
-            _replace_variables(k, db): _replace_variables(v, db) for k, v in x.items()
+            _replace_variables(k, db, **kwargs): _replace_variables(v, db, **kwargs)
+            for k, v in x.items()
         }
     if isinstance(x, (list, tuple)):
         return [_replace_variables(v, db) for v in x]
     if isinstance(x, Variable):
-        return x.set(db)
+        return x.set(db, **kwargs)
+    if isinstance(x, Document):
+        return x.set_variables(db, **kwargs)
     return x
 
 
@@ -161,13 +137,67 @@ class Serializable:
     serialize = _serialize
 
     @property
-    def variables(self) -> t.List[Variable]:
-        return _find_variables(self.dict())
+    def variables(self) -> t.List['Variable']:
+        out = {}
+        v = _find_variables(self.dict())
+        for var in v:
+            out[var.value] = var
+        return sorted(list(out.values()), key=lambda x: x.value)
 
-    def set_variables(self, db) -> 'Serializable':
-        r = self.serialize()  # get serialized version of class instance
-        r = _replace_variables(r, db)  # replace variables with values
+    def set_variables(self, db, **kwargs) -> 'Serializable':
+        r = self.serialize(
+            serialize_variables=False
+        )  # get serialized version of class instance
+        r = _replace_variables(r, db, **kwargs)  # replace variables with values
         return self.deserialize(r)  # rebuild new class instance
 
     def dict(self) -> t.Dict[str, t.Any]:
         return asdict(self)
+
+
+class Variable:
+    """
+    Mechanism for allowing "free variables" in a serializable object.
+    The idea is to allow a variable to be set at runtime, rather than
+    at object creation time.
+
+    :param value: The name of the variable to be set at runtime.
+    :param setter_callback: A callback function that takes the value, datalayer
+                            and kwargs as input and returns the formatted
+                            variable.
+    """
+
+    def __init__(
+        self, value: t.Union[str, t.Any], setter_callback: t.Optional[t.Callable] = None
+    ):
+        self.value = value
+        self.setter_callback = setter_callback
+
+    def __repr__(self) -> str:
+        return '$' + str(self.value)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def set(self, db, **kwargs):
+        """
+        Get the intended value from the values of the global variables.
+
+        >>> Variable('number').set(db, number=1.5, other='test')
+        1.5
+
+        :param db: The datalayer instance.
+        :param kwargs: Variables to be used in the setter_callback
+                       or as formatting variables.
+        """
+        if self.setter_callback is not None:
+            try:
+                return self.setter_callback(db, self.value, kwargs)
+            except Exception as e:
+                raise VariableError(
+                    f'Could not set variable {self.value} '
+                    f'based on {self.setter_callback} and **kwargs: {kwargs}'
+                ) from e
+        else:
+            assert isinstance(self.value, str)
+            return kwargs[self.value]

--- a/superduperdb/components/component.py
+++ b/superduperdb/components/component.py
@@ -25,10 +25,19 @@ class Component(Serializable):
     type_id: t.ClassVar[str]
     identifier: str
 
+    @property
+    def db(self):
+        return self._db
+
+    @db.setter
+    def db(self, value: Datalayer):
+        self._db = value
+
     def __post_init__(self) -> None:
         # set version in `__post_init__` so that is
         # cannot be set in `__init__` and is always set
         self.version: t.Optional[int] = None
+        self._db = None  # type: ignore[assignment]
 
     def pre_create(self, db: Datalayer) -> None:
         """Called the first time this component is created

--- a/superduperdb/ext/cohere/model.py
+++ b/superduperdb/ext/cohere/model.py
@@ -25,6 +25,7 @@ class Cohere(APIModel):
     client_kwargs: t.Dict[str, t.Any] = dc.field(default_factory=dict)
 
     def __post_init__(self):
+        super().__post_init__()
         self.identifier = self.identifier or self.model
 
 

--- a/superduperdb/ext/jina/model.py
+++ b/superduperdb/ext/jina/model.py
@@ -16,6 +16,7 @@ class Jina(APIModel):
     api_key: t.Optional[str] = None
 
     def __post_init__(self):
+        super().__post_init__()
         self.identifier = self.identifier or self.model
         self.client = JinaAPIClient(model_name=self.identifier, api_key=self.api_key)
 

--- a/test/unittest/test_quality.py
+++ b/test/unittest/test_quality.py
@@ -17,9 +17,9 @@ DEFECTS = {
 # over time.  If you have decreased the number of defects, change it here,
 # and take a bow!
 ALLOWABLE_DEFECTS = {
-    'cast': 15,  # Try to keep this down
+    'cast': 16,  # Try to keep this down
     'noqa': 4,  # This should never change
-    'type_ignore': 29,  # This should only ever increase in obscure edge cases
+    'type_ignore': 33,  # This should only ever increase in obscure edge cases
 }
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

This PR adds additional parameters to `.predict` to allow single outputs to be saved back into the database.
In addition, this adds a few new `_Predictor` descendants which allow users to implement search and easier model chaining.

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make test` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
