### PR TITLE
Python package references are updated in sql.md 

### DIFF
--- a/docs/hr/content/docs/data_integrations/sql.md
+++ b/docs/hr/content/docs/data_integrations/sql.md
@@ -13,7 +13,8 @@ support for complex data-types and vector-searches.
 The first step in working with an SQL table, is to define a table and schema
 
 ```python
-from superduperdb.backends.ibis import dtype, Table
+from superduperdb.backends.ibis.query import Table
+from superduperdb.backends.ibis.field_types import dtype
 from superduperdb import Encoder, Schema
 
 my_enc = Encoder('my-enc')


### PR DESCRIPTION
## Description
The example in the documentation refers to the old Python references for dtype and Table and I've updated the references in this fix.

## Related Issues

[ Python package references need to be updated.](https://github.com/SuperDuperDB/superduperdb/issues/1569)

Examples:
   Python references are updated (fix #1569)
    
## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
