### PR TITLE
Artifacts from URIs and stack refactorings

### DIFF
--- a/superduperdb/components/serializer.py
+++ b/superduperdb/components/serializer.py
@@ -1,9 +1,13 @@
 import dataclasses as dc
+import io
+import pickle
 import typing as t
 
+import dill
+
+from superduperdb.base.artifact import Artifact
 from superduperdb.components.component import Component
 from superduperdb.misc.annotations import public_api
-from superduperdb.misc.serialization import serializers
 
 if t.TYPE_CHECKING:
     from superduperdb.base.datalayer import Datalayer
@@ -23,9 +27,127 @@ class Serializer(Component):
 
     type_id: t.ClassVar[str] = 'serializer'
 
-    object: t.Type
+    encoder: t.Union[t.Callable, Artifact]
+    decoder: t.Union[t.Callable, Artifact]
+    constructor: t.Union[t.Callable, Artifact, str, None] = None
+
+    info: t.Optional[t.Dict] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if not isinstance(self.encoder, Artifact):
+            self.encoder = Artifact(self.encoder)
+        if not isinstance(self.decoder, Artifact):
+            self.decoder = Artifact(self.decoder)
+        if self.constructor and not isinstance(self.constructor, Artifact):
+            self.constructor = Artifact(self.constructor)
 
     def pre_create(self, db: 'Datalayer'):
         super().pre_create(db)
-        serializers.add(self.identifier, self.object)
         self.object = t.cast(t.Type, self.identifier)
+
+    def encode(self, object: t.Any) -> bytes:
+        assert isinstance(self.encoder, Artifact)
+        return self.encoder.artifact(object, info=self.info)
+
+    def decode(self, object: t.Any) -> bytes:
+        assert isinstance(self.decoder, Artifact)
+        return self.decoder.artifact(object, info=self.info)
+
+    def construct(self):
+        assert isinstance(self.constructor, Artifact)
+        return self.constructor.artifact(**self.info)
+
+
+def pickle_encode(object: t.Any, info: t.Optional[t.Dict] = None) -> bytes:
+    return pickle.dumps(object)
+
+
+def pickle_decode(b: bytes, info: t.Optional[t.Dict] = None) -> t.Any:
+    return pickle.loads(b)
+
+
+def dill_encode(object: t.Any, info: t.Optional[t.Dict] = None) -> bytes:
+    return dill.dumps(object)
+
+
+def dill_decode(b: bytes, info: t.Optional[t.Dict] = None) -> t.Any:
+    return dill.loads(b)
+
+
+def torch_encode(object: t.Any, info: t.Optional[t.Dict] = None) -> bytes:
+    import torch
+
+    from superduperdb.ext.torch.utils import device_of
+
+    if not isinstance(object, dict):
+        previous_device = str(device_of(object))
+        object.to('cpu')
+        f = io.BytesIO()
+        torch.save(object, f)
+        object.to(previous_device)
+    else:
+        f = io.BytesIO()
+        torch.save(object, f)
+    return f.getvalue()
+
+
+def torch_decode(b: bytes, info: t.Optional[t.Dict] = None) -> t.Any:
+    import torch
+
+    return torch.load(io.BytesIO(b))
+
+
+class Serializers:
+    serializers: t.Dict[str, Serializer] = {}
+
+    def __iter__(self):
+        return iter(self.serializers)
+
+    def add(self, name: str, serializer: Serializer):
+        self.serializers[name] = serializer
+
+    def __getitem__(self, serializer):
+        return self.serializers[serializer]
+
+
+serializers = Serializers()
+serializers.add(
+    'pickle', Serializer('pickle', encoder=pickle_encode, decoder=pickle_decode)
+)
+serializers.add('dill', Serializer('dill', encoder=dill_encode, decoder=dill_decode))
+serializers.add(
+    'torch', Serializer('torch', encoder=torch_encode, decoder=torch_decode)
+)
+
+
+def encode_torch_state_dict(module, info):
+    import torch
+
+    buffer = io.BytesIO()
+    torch.save(module.state_dict(), buffer)
+
+    return buffer.getvalue()
+
+
+class DecodeTorchStateDict:
+    def __init__(self, cls):
+        self.cls = cls
+
+    def __call__(self, b: bytes, info: t.Dict):
+        import torch
+
+        buffer = io.BytesIO(b)
+        module = self.cls(**info)
+        module.load_state_dict(torch.load(buffer))
+        return module
+
+
+def build_torch_state_serializer(module, info):
+    return Serializer(
+        identifier=module.__name__,
+        info=info,
+        encoder=encode_torch_state_dict,
+        decoder=DecodeTorchStateDict(module),
+    )

--- a/superduperdb/components/stack.py
+++ b/superduperdb/components/stack.py
@@ -1,17 +1,21 @@
 import dataclasses as dc
+import importlib
 import json
 import os
+import re
 import tarfile
 import typing as t
 
 from superduperdb.backends.local.artifacts import FileSystemArtifactStore
 from superduperdb.base.serializable import Serializable
+from superduperdb.components.serializer import serializers
 from superduperdb.misc.annotations import public_api
+from superduperdb.misc.download import Fetcher
 
 from .component import Component
 
 if t.TYPE_CHECKING:
-    from superduperdb.base.datalayer import Datalayer as DB
+    from superduperdb.base.datalayer import Datalayer
 
 
 ARTIFACTS = 'artifacts'
@@ -80,7 +84,7 @@ class Stack(Component):
             tar.extractall(path=extract_path)
         return extract_path
 
-    def save(self, db: 'DB', name: str):
+    def save(self, db: 'Datalayer', name: str):
         """
         Save method takes a stack name and exports ``self``
         to tarball by serializing ``Stack`` along with storing
@@ -119,7 +123,7 @@ class Stack(Component):
             serialized = json.load(inputfile)
 
         # Load the stack
-        fs_store = FileSystemArtifactStore(os.path.join(extracted_path, ARTIFACTS))
+        fs_store = os.path.join(extracted_path, ARTIFACTS)
         info = fs_store.load(serialized, lazy=True)
         loaded_stack = Serializable.deserialize(info)
 
@@ -132,3 +136,141 @@ class Stack(Component):
 
     def get_component_type(self, type_id: str):
         return self._component_type_store.get(type_id, None)
+
+    @staticmethod
+    def from_dict(d: t.Dict, db: t.Optional['Datalayer'] = None):
+        """
+        Load a stack from a dictionary.
+
+        :param d: Dictionary containing the stack definition.
+        :param db: Datalayer instance to use for loading artifacts.
+
+        The dictionary should look something like below.
+        1. An ``identifier`` field
+        2. An ``artifact`` field containing a list of artifacts including the
+           serializer used
+        3. A ``components`` field containing a list of component definitions.
+           These definitions can recursively refer to other components or artifacts,
+           resp. ``$components.<identifier>`` or ``$artifacts[<index>]``.
+
+        >>> d = {
+        ...    'identifier': 'my_stack',
+        ...    'artifacts': [
+        ...        {
+        ...            'serializer': 'pickle',
+        ...            'bytes': bytes_,
+        ...        },
+        ...    ],
+        ...    'components': [
+        ...        {'module': 'superduperdb.ext.pillow', 'variable': 'pil_image'},
+        ...        {
+        ...            'module': 'superduperdb.components.model',
+        ...            'cls': 'Model',
+        ...            'dict': {
+        ...                'identifier': 'my_model',
+        ...                'object': '$artifacts[0]',
+        ...                'encoder': '$components.pil_image',
+        ...            },
+        ...        },
+        ...    ],
+        ... }
+        >>> s = Stack.from_dict(d)
+        >>> isinstance(s, Stack)
+        True
+        >>> isinstance(s.components[1], Model)
+        True
+
+        """
+        return _load_stack(d, db)
+
+
+def _find_variables(r):
+    if 'dict' not in r:
+        return []
+    variables = []
+    for k in r['dict']:
+        if isinstance(r['dict'][k], str) and r['dict'][k].startswith('$components'):
+            variables.append(r['dict'][k])
+    return variables
+
+
+def _find_leaves(components, existing):
+    def contains_new_variable(r):
+        if set(_find_variables(r)).issubset(set(existing)):
+            return False
+        return True
+
+    out = [c for c in components if not contains_new_variable(c)]
+    components = [c for c in components if contains_new_variable(c)]
+    return out, components
+
+
+def _load_artifact(variable, artifacts, serializers, dir=None, fetcher=None):
+    serializer = serializers[artifacts[variable]['serializer']]
+    if 'bytes' not in artifacts[variable]:
+        fetcher = fetcher or Fetcher()
+        try:
+            uri = artifacts[variable]['uri']
+        except KeyError:
+            raise Exception(f'No uri or bytes found for artifact {variable}')
+
+        artifacts[variable]['bytes'] = fetcher(uri)
+    return serializer.decode(artifacts[variable]['bytes'])
+
+
+def _build_component(d, artifacts, components, serializers):
+    module = importlib.import_module(d['module'])
+    if 'dict' in d:
+        defn = d['dict'].copy()
+        for k in defn:
+            if isinstance(defn[k], str) and defn[k].startswith('$'):
+                if '.' in defn[k]:
+                    assert defn[k].startswith('$components.')
+                    type, variable = defn[k][1:].split('.')
+                else:
+                    match = re.match('\$artifacts\[(\d+)\]', defn[k])
+                    assert (
+                        match
+                    ), 'Unknown variable type {defn[k]}, expected $artifacts[<index>]'
+                    type = 'artifacts'
+                    variable = int(match.groups()[0].strip())
+
+                if type == 'artifacts':
+                    if 'artifact' not in artifacts[variable]:
+                        artifacts[variable]['artifact'] = _load_artifact(
+                            variable, artifacts, serializers=serializers
+                        )
+                    defn[k] = artifacts[variable]['artifact']
+                elif type == 'components':
+                    defn[k] = {c.identifier: c for c in components}[variable]
+                else:
+                    raise Exception(f'Unknown variable type {type}')
+
+        component_cls = getattr(module, d['cls'])
+        built = component_cls(**defn)
+        if built.type_id == 'serializer':
+            serializers[built.identifier] = built.object
+    else:
+        built = getattr(module, d['variable'])
+    return built
+
+
+def _load_stack(d, db=None):
+    components = []
+    to_build = d['components'].copy()
+    while True:
+        current, to_build = _find_leaves(
+            to_build,
+            existing=[f'$components.{c.identifier}' for c in components],
+        )
+        for c in current:
+            built = _build_component(
+                c,
+                artifacts=d['artifacts'],
+                components=components,
+                serializers=db.serializers if db else serializers,
+            )
+            components.append(built)
+        if not to_build:
+            break
+    return Stack(identifier=d['identifier'], components=components)

--- a/superduperdb/misc/serialization.py
+++ b/superduperdb/misc/serialization.py
@@ -1,15 +1,7 @@
 import copy
 import dataclasses as dc
-import io
-import pickle
 import types
 import typing as t
-from abc import ABC
-
-import dill
-import typing_extensions as te
-
-Info = t.Optional[t.Dict[str, t.Any]]
 
 _ATOMIC_TYPES = frozenset(
     {
@@ -33,107 +25,6 @@ _ATOMIC_TYPES = frozenset(
         property,
     }
 )
-
-
-class ModuleClassDict(te.TypedDict):
-    """
-    A ``dict``with the module, class and JSONization of an object
-
-    :param module: The module of the object
-    """
-
-    module: str
-    cls: str
-    dict: t.Dict[str, t.Any]
-
-
-class Serializer(ABC):
-    @staticmethod
-    def encode(object: t.Any, info: Info = None) -> bytes:
-        raise NotImplementedError
-
-    @staticmethod
-    def decode(b: bytes, info: Info = None) -> t.Any:
-        raise NotImplementedError
-
-
-class PickleSerializer(Serializer):
-    @staticmethod
-    def encode(object: t.Any, info: Info = None) -> bytes:
-        return pickle.dumps(object)
-
-    @staticmethod
-    def decode(b: bytes, info: Info = None) -> t.Any:
-        return pickle.loads(b)
-
-
-class DillSerializer(Serializer):
-    @staticmethod
-    def encode(object: t.Any, info: Info = None) -> bytes:
-        return dill.dumps(object)
-
-    @staticmethod
-    def decode(b: bytes, info: Info = None) -> t.Any:
-        return dill.loads(b)
-
-
-class TorchSerializer(Serializer):
-    @staticmethod
-    def encode(object: t.Any, info: Info = None) -> bytes:
-        import torch
-
-        from superduperdb.ext.torch.utils import device_of
-
-        if not isinstance(object, dict):
-            previous_device = str(device_of(object))
-            object.to('cpu')
-            f = io.BytesIO()
-            torch.save(object, f)
-            object.to(previous_device)
-        else:
-            f = io.BytesIO()
-            torch.save(object, f)
-        return f.getvalue()
-
-    @staticmethod
-    def decode(b: bytes, info: Info = None) -> t.Any:
-        import torch
-
-        return torch.load(io.BytesIO(b))
-
-
-class Serializers:
-    serializers: t.Dict[str, t.Type] = {}
-
-    def add(self, name: str, serializer: t.Type):
-        self.serializers[name] = serializer
-
-    def __getitem__(self, serializer):
-        return self.serializers[serializer]
-
-
-serializers = Serializers()
-serializers.add('pickle', PickleSerializer)
-serializers.add('dill', DillSerializer)
-serializers.add('torch', TorchSerializer)
-
-
-class Method:
-    """
-    A callable that calls a method on the object it is called with.
-
-    :param method: The method to call.
-    :param *args: The args to call the method with.
-    :param **kwargs: The kwargs to call the method with.
-    """
-
-    def __init__(self, method: str, *args, **kwargs):
-        self.method = method
-        self.args = args
-        self.kwargs = kwargs
-
-    def __call__(self, X: t.Any) -> t.Any:
-        return getattr(X, self.method)(*self.args, **self.kwargs)
 
 
 def asdict(obj, *, copy_method=copy.copy) -> t.Dict[str, t.Any]:

--- a/test/unittest/base/test_datalayer.py
+++ b/test/unittest/base/test_datalayer.py
@@ -158,7 +158,7 @@ def test_add_artifact_auto_replace(db):
     with patch.object(db.metadata, 'create_component') as create_component:
         db.add(component)
         serialized = create_component.call_args[0][0]
-        assert serialized['dict']['artifact']['sha1'] == artifact.sha1
+        assert serialized['dict']['artifact']['sha1'] == artifact.sha1(db.serializers)
 
 
 @pytest.mark.parametrize(

--- a/test/unittest/component/test_serializer.py
+++ b/test/unittest/component/test_serializer.py
@@ -1,0 +1,33 @@
+from test.db_config import DBConfig
+
+import pytest
+import torch.nn
+
+from superduperdb.components.serializer import build_torch_state_serializer
+
+
+@pytest.mark.parametrize("db", [DBConfig.mongodb_empty], indirect=True)
+def test_custom_serializer(db):
+    s = build_torch_state_serializer(
+        torch.nn.Linear,
+        {'in_features': 10, 'out_features': 32, 'bias': False},
+    )
+
+    m = torch.nn.Linear(10, 32, bias=False)
+    bytes_ = s.encode(m)
+
+    n = s.decode(bytes_)
+
+    assert isinstance(n, torch.nn.Linear)
+    assert n.weight.shape == m.weight.shape
+    assert (n.weight.flatten() == m.weight.flatten()).sum().item() == m.weight.shape[
+        0
+    ] * m.weight.shape[1]
+
+    db.add(s)
+
+    s_reload = db.load('serializer', s.identifier)
+
+    double_encoded = s_reload.decode(s_reload.encode(m))
+
+    assert isinstance(double_encoded, torch.nn.Linear)

--- a/test/unittest/component/test_stack.py
+++ b/test/unittest/component/test_stack.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from superduperdb.components.model import Model
+from superduperdb.components.serializer import serializers
+from superduperdb.components.stack import Stack
+
+
+@pytest.fixture
+def stack():
+    pickler = serializers['pickle']
+    bytes_ = pickler.encode(torch.nn.Linear(10, 32))
+
+    return {
+        'identifier': 'my_stack',
+        'artifacts': [
+            {
+                'serializer': 'pickle',
+                'bytes': bytes_,
+            },
+        ],
+        'components': [
+            {'module': 'superduperdb.ext.pillow', 'variable': 'pil_image'},
+            {
+                'module': 'superduperdb.components.model',
+                'cls': 'Model',
+                'dict': {
+                    'identifier': 'my_model',
+                    'object': '$artifacts[0]',
+                    'encoder': '$components.pil_image',
+                },
+            },
+        ],
+    }
+
+
+def test_from_dict(stack):
+    s = Stack.from_dict(stack)
+    assert isinstance(s.components[1], Model)


### PR DESCRIPTION
Add function to extract a stack from a JSON, YAML or dictionary.

In order to make this possible, we need a broader conception of serializer which I provided in a refactoring
of the `Serializer` class. This required moving around some arguments.