### PR TITLE
Feature/multi ids

### DIFF
--- a/superduperdb/backends/base/query.py
+++ b/superduperdb/backends/base/query.py
@@ -10,7 +10,7 @@ from superduperdb.base.serializable import Serializable, Variable
 
 GREEN = '\033[92m'
 BOLD = '\033[1m'
-END = '\033[0m}'
+END = '\033[0m'
 
 
 class _ReprMixin(ABC):

--- a/superduperdb/backends/ibis/data_backend.py
+++ b/superduperdb/backends/ibis/data_backend.py
@@ -16,6 +16,7 @@ from superduperdb.components.model import APIModel, Model
 from superduperdb.components.schema import Schema
 
 BASE64_PREFIX = 'base64:'
+INPUT_KEY = '_input_id'
 
 
 class IbisDataBackend(BaseDataBackend):
@@ -60,8 +61,7 @@ class IbisDataBackend(BaseDataBackend):
         else:
             output_type = model.encoder
         fields = {
-            'output_id': dtype('str'),  # TODO why do we need this????
-            'input_id': dtype('str'),
+            INPUT_KEY: dtype('string'),
             'query_id': dtype('string'),
             'output': output_type,
             'key': dtype('string'),

--- a/superduperdb/ext/sentence_transformers/model.py
+++ b/superduperdb/ext/sentence_transformers/model.py
@@ -1,8 +1,6 @@
 import dataclasses as dc
 import typing as t
 
-import sentence_transformers
-
 from superduperdb.base.artifact import Artifact
 from superduperdb.components.model import Model
 
@@ -14,6 +12,8 @@ class SentenceTransformer(Model):
     def __post_init__(self):
         super().__post_init__()
         if self.object is None:
+            import sentence_transformers
+
             self.object = Artifact(
                 artifact=sentence_transformers.SentenceTransformer(
                     self.identifier, device=self.device

--- a/superduperdb/vector_search/update_tasks.py
+++ b/superduperdb/vector_search/update_tasks.py
@@ -61,10 +61,12 @@ def copy_vectors(
         ]
     elif isinstance(db.databackend, IbisDataBackend):
         docs = db.execute(select.outputs(**{key: model}))
+        from superduperdb.backends.ibis.data_backend import INPUT_KEY
+
         vectors = [
             {
                 'vector': doc['_outputs.{key}.{model}.{version}'].x,
-                'id': str(doc['input_id']),
+                'id': str(doc[INPUT_KEY]),
             }
             for doc in docs
         ]

--- a/test/integration/test_cdc.py
+++ b/test/integration/test_cdc.py
@@ -493,7 +493,7 @@ def test_sql_task_workflow(
             t = database_with_listeners.databackend.conn.table(
                 '_outputs_model_linear_a_0'
             )
-            outputs = t.select('input_id').execute()
+            outputs = t.select('_input_id').execute()
             assert len(outputs) == 2
 
         retry_state_check(state_check, 3, 1)

--- a/test/unittest/backends/ibis/test_query.py
+++ b/test/unittest/backends/ibis/test_query.py
@@ -62,7 +62,9 @@ def duckdb():
         )
 
         db.execute(
-            t.insert(pandas.DataFrame([{'x': f'test::{i}', 'id': str(i)} for i in range(20)]))
+            t.insert(
+                pandas.DataFrame([{'x': f'test::{i}', 'id': str(i)} for i in range(20)])
+            )
         )
 
         model = Model(
@@ -84,25 +86,20 @@ def duckdb():
         )
 
         db.execute(
-            s.insert(pandas.DataFrame([{'y': f'test2::{i}', 'other_id': str(i // 2), 'id2': str(i)} for i in range(40)]))
+            s.insert(
+                pandas.DataFrame(
+                    [
+                        {'y': f'test2::{i}', 'other_id': str(i // 2), 'id2': str(i)}
+                        for i in range(40)
+                    ]
+                )
+            )
         )
 
         yield db
 
 
-# def test_multi_ids(duckdb):
-#     s = duckdb.load('table', 'other')
-#     t = duckdb.load('table', 'test')
-#     df = duckdb.execute(t.join(s, t.id == s.other_id)).as_pandas()
-#     df = df.astype({'id': int, 'other_id': int})
-#     df = df.sort_values(by=['id', 'other_id'])
-
-#     # df = duckdb.execute(s).as_pandas()
-#     # df = duckdb.execute(t).as_pandas()
-
-
 def test_auto_inference_primary_id():
-
     s = IbisQueryTable('other', primary_id='other_id')
     t = IbisQueryTable('test', primary_id='id')
 


### PR DESCRIPTION
This PR solves the potential issue that users attempt to apply a `Model` to a query which doesn't have uniquely identifying rows. 

We enforce this now, by inferring which `primary_ids` stemming from `Table` instances in a query occur in a query, but factor out those which are eliminated by a `group_by` statement.