### PR TITLE
docs: update images location

### DIFF
--- a/docs/hr/content/docs/ai_integrations/jina.md
+++ b/docs/hr/content/docs/ai_integrations/jina.md
@@ -1,4 +1,4 @@
-#Jina
+# Jina
 
 `superduperdb` allows users to work with `Jina Embeddings models` through the Jina Embedding API.
 

--- a/docs/hr/content/docs/fundamentals/architecture.md
+++ b/docs/hr/content/docs/fundamentals/architecture.md
@@ -2,4 +2,4 @@
 
 Here is a detailed view of the `superduperdb` architecture:
 
-![architecture_detailed](/img/architecture_detailed.png)
+![architecture_detailed](../../../static/img/architecture_detailed.png)

--- a/docs/hr/content/docs/fundamentals/design.md
+++ b/docs/hr/content/docs/fundamentals/design.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 Here is a schematic of the `superduperdb` design.
 
-![](/img/light.png)
+![light](../../../static/img/light.png)
 
 ## Explanation
 

--- a/docs/hr/content/docs/fundamentals/vector_search_algorithm.md
+++ b/docs/hr/content/docs/fundamentals/vector_search_algorithm.md
@@ -21,7 +21,7 @@ using the system:
 
 Here is a schematic of how vector-search works:
 
-![](/img/vector-search.png)
+![vector-search](../../../static/img/vector-search.png)
 
 ## Explanation
 

--- a/docs/hr/content/docs/intro.md
+++ b/docs/hr/content/docs/intro.md
@@ -15,7 +15,7 @@ By integrating AI at the data's source, we aim to make building AI applications 
 For more information about SuperDuperDB and why we believe it is much needed, [read this blog post](https://docs.superduperdb.com/blog/superduperdb-the-open-source-framework-for-bringing-ai-to-your-datastore/). 
 
 
-![](/img/superduperdb.gif)
+![superduperdb](../../static/img/superduperdb.gif)
 
 
 

--- a/docs/hr/content/docs/walkthrough/tutorial_walkthrough.md
+++ b/docs/hr/content/docs/walkthrough/tutorial_walkthrough.md
@@ -19,4 +19,4 @@ You'll probably also want to ready about the query API which is relevant to your
 - [MongoDB Query API](../data_integrations/mongodb.md)
 - [Ibis Query API for SQL](../data_integrations/sql.md)
 
-![](/img/walkthrough.png)
+![walkthrough](../../../static/img/walkthrough.png)

--- a/docs/hr/content/use_cases/productionization/sandbox-example.md
+++ b/docs/hr/content/use_cases/productionization/sandbox-example.md
@@ -7,7 +7,7 @@ SuperDuperDB allows developers, on the one hand to experiment and setup models q
 - Vector-searcher service
 - Change-data-capture (CDC) service
 
-![](/img/light.png)
+![light](../../../static/img/light.png)
 
 To set up `superduperdb` to use this cluster mode, it's necessary to add explicit configurations 
 for each of these components. The following configuration does that, as well as enabling a pre-configured 

--- a/docs/hr/content/use_cases/sql_examples/snowflake-example.md
+++ b/docs/hr/content/use_cases/sql_examples/snowflake-example.md
@@ -11,7 +11,7 @@ Here is the notebook [notebook](https://github.com/SuperDuperDB/superduperdb/blo
 The first step in doing this is 
 to connect to your snowflake account. When you log in it should look something like this:
 
-![](/img/snowflake-login.png)
+![snowflake-login](../../../static/img/snowflake-login.png)
 
 The important thing you need to get from this login is the **organization-id** and **user-id** from the menu in the bottom right (annotated on the image). You will set these values in the cell below.
 
@@ -100,7 +100,7 @@ _, t = db.add(
 
 If you log back into Snowflake now it should look like this:
 
-![](/img/snowflake-table.png)
+![snowflake-table](../../../static/img/snowflake-table.png)
 
 You'll see that the database and table have been created.
 


### PR DESCRIPTION
## Description
Oops, I didn't realize #1638 would break the Docusaurus. Now, it should work fine.

I updated multiple images location in the docs to make them display on GitHub source code as well.
Additionally, fixed a small typo in `jina.md`. 

## Related Issues


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
In the [Docusaurus example](https://github.com/facebook/docusaurus/tree/main/examples/classic/docs/tutorial-extras), each content has its own `img` folder, which I think makes it easier to find images as the blog grows, rather than having them all in the static folder.