### PR TITLE
run testing within the sandbox image

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -60,39 +60,39 @@ jobs:
           python -m pip install impall==1.3.1
           python -m impall --NO_CLEAR_SYS_MODULES -E 'test**:superduperdb/ext**'
 
+      - name: Basic health check
+        run: |
+          black --version
+          ruff --version
+          mypy --version
+
       - name: Lint and type-check
         run: |
           make lint-and-type-check
 
-      - name: Build Sandbox Image
+      - name: Unit Testing
         run: |
-          # Build sandbox image for testing.
-          make testenv_image
+          make unit-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"
 
-      - name: Run Unit Testing
-        run: |
-          # Run unit tests, within the sandbox image. This is to avoid downloading dependencies once for the
-          # container, and once for the host.
-          docker run --net=host --entrypoint '/bin/sh' superduperdb/sandbox:latest -c 'make unit-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"'
+      - name: Cleanup Docker
+        run: |    
+          docker system prune -af
 
-
-      - name: Start Testing Environment
+      - name: Integration Testing
+        if: ${{ startsWith(matrix.python-version, '3.11') }} # Dask requires local python and Dockerfile to be in sync
         run: |
           # Update hostnames
           echo  127.0.0.1 mongodb | sudo tee -a /etc/hosts
           
+          # Build sandbox image for testing.
+          make testenv_image
+          
           # Run the integrated testing environment
           make testenv_init
-
-      - name: Run Integration Testing
-        if: ${{ startsWith(matrix.python-version, '3.11') }} # Dask requires local python and Dockerfile to be in sync
-        run: |
-          # Run unit tests, within the sandbox image. This is to avoid downloading dependencies once for the
-          # container, and once for the host.
-          docker run --net=host --entrypoint '/bin/sh' superduperdb/sandbox:latest -c 'make integration-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"'
-
-      - name: Shutdown Testing Environment
-        run: |
+          
+          # Run the test-suite
+          make integration-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"
+          
           # Destroy the testing environment
           make testenv_shutdown
 

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -60,35 +60,39 @@ jobs:
           python -m pip install impall==1.3.1
           python -m impall --NO_CLEAR_SYS_MODULES -E 'test**:superduperdb/ext**'
 
-      - name: Basic health check
-        run: |
-          black --version
-          ruff --version
-          mypy --version
-
       - name: Lint and type-check
         run: |
           make lint-and-type-check
 
-      - name: Unit Testing
+      - name: Build Sandbox Image
         run: |
-          make unit-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"
+          # Build sandbox image for testing.
+          make testenv_image
 
-      - name: Integration Testing
-        if: ${{ startsWith(matrix.python-version, '3.11') }} # Dask requires local python and Dockerfile to be in sync
+      - name: Run Unit Testing
+        run: |
+          # Run unit tests, within the sandbox image. This is to avoid downloading dependencies once for the
+          # container, and once for the host.
+          docker run --net=host --entrypoint '/bin/sh' superduperdb/sandbox:latest -c 'make unit-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"'
+
+
+      - name: Start Testing Environment
         run: |
           # Update hostnames
           echo  127.0.0.1 mongodb | sudo tee -a /etc/hosts
           
-          # Build sandbox image for testing.
-          make testenv_image
-          
           # Run the integrated testing environment
           make testenv_init
-          
-          # Run the test-suite
-          make integration-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"
-          
+
+      - name: Run Integration Testing
+        if: ${{ startsWith(matrix.python-version, '3.11') }} # Dask requires local python and Dockerfile to be in sync
+        run: |
+          # Run unit tests, within the sandbox image. This is to avoid downloading dependencies once for the
+          # container, and once for the host.
+          docker run --net=host --entrypoint '/bin/sh' superduperdb/sandbox:latest -c 'make integration-testing PYTEST_ARGUMENTS="--cov=superduperdb --cov-report=xml"'
+
+      - name: Shutdown Testing Environment
+        run: |
           # Destroy the testing environment
           make testenv_shutdown
 

--- a/.github/workflows/ci_docs.yaml
+++ b/.github/workflows/ci_docs.yaml
@@ -49,7 +49,6 @@ jobs:
         run: |
           # Build HR and API docs
           make build-docs
-          
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced JSON data with String format before storage in SQLAlchemy.
 - Implemented storage of byte data in base64 format.
 - Migrated MongoDB Atlas vector search as a standalone searcher like lance.
+- Deprecated Demo Image. Now Notebooks run in Colab.
+- Replace dask with ray compute backend
 
 #### New Features & Functionality
 
@@ -27,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `insert_to=<table-or-collection>` to `.predict` to allow single predictions to be saved.
 - Support vLLM (running locally or remotely on a ray cluster)
 - Support LLM service in OpenAI format
-- Add ray compute backend
 
 #### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ testenv_init: ## Initialize a local Testing environment
 
 	SUPERDUPERDB_DATA_DIR=$(SUPERDUPERDB_DATA_DIR) docker compose -f deploy/testenv/docker-compose.yaml up --remove-orphans &
 
+	# Block waiting for the testenv to become ready.
+	@cd deploy/testenv/; ./wait_ready.sh
+
 testenv_shutdown: ## Terminate the local Testing environment
 	@echo "===> Shutting down the local Testing environment"
 	docker compose -f deploy/testenv/docker-compose.yaml down
@@ -179,10 +182,6 @@ unit-testing: ## Execute unit testing
 	pytest $(PYTEST_ARGUMENTS) ./test/unittest/
 
 integration-testing: ## Execute integration testing
-	# Block waiting for the testenv to become ready.
-	@cd deploy/testenv/; ./wait_ready.sh
-
-	# Run the test
 	pytest $(PYTEST_ARGUMENTS) ./test/integration
 
 test_notebooks: ## Test notebooks (argument: NOTEBOOKS=<test|dir>)

--- a/deploy/images/superduperdb/Dockerfile
+++ b/deploy/images/superduperdb/Dockerfile
@@ -58,14 +58,13 @@ ENV PATH="${HOME}/.local/bin:$PATH"
 
 # Install common dependencies
 # ---------------
-RUN pip install --upgrade setuptools pip
-RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip pip install --upgrade --user \
+RUN pip install setuptools pip
+RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user \
     # JupyterLab extensions \
     theme-darcula \
     ipywidgets \
     jupyterlab-lsp \
-    'python-lsp-server[all]' \
-    "dask-labextension>=5"
+    'python-lsp-server[all]'
 
 
 # Install Jupyterlab extensions
@@ -97,10 +96,9 @@ ONBUILD ARG SUPERDUPERDB_EXTRAS=''
 ONBUILD COPY --chown=superduper ./ ${HOME}/superduperdb
 ONBUILD WORKDIR ${HOME}/superduperdb
 # Install project dependencies.
-ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip pip install --user --editable \
-    .[${SUPERDUPERDB_EXTRAS}]
+ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user --editable .[${SUPERDUPERDB_EXTRAS}]
 # Install user-defined dependencies
-ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip pip install --user  -r requirements.txt
+ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user  -r requirements.txt
 
 # ---------------
 # Build Release
@@ -111,8 +109,7 @@ ONBUILD ARG SUPERDUPERDB_EXTRAS=''
 ONBUILD COPY --chown=superduper ${PWD}/examples ./examples
 ONBUILD COPY --chown=superduper ${PWD}/contrib ./contrib
 # Drop cache to reduce image size.
-ONBUILD RUN pip install --upgrade --user \
-    superduperdb[${SUPERDUPERDB_EXTRAS}] \
+ONBUILD RUN python -m pip install --user superduperdb[${SUPERDUPERDB_EXTRAS}] \
     # Purge pip cache
     && pip cache purge
 ONBUILD WORKDIR ${HOME}/examples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

Change CI to run unit test and integration test within the testenv_image. This is to avoid downloading duplicate dependencies that cause CI nodes to run out of disk.

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes https://github.com/SuperDuperDB/superduperdb/issues/1684 https://github.com/SuperDuperDB/superduperdb/issues/1745

## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
