### PR TITLE
make CI to fail if changelog is not updated

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+        # Remind users to update changelog
+      - name: Check Changelog Action
+        uses: tarides/changelog-check-action@v2
+        with:
+            changelog: CHANGELOG.md
+
       #---------------------------------------------------
       # Configuring Python environments.
       #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changes Since Last Release
 
 #### Changed defaults / behaviours
+- 
+
+#### New Features & Functionality
+- CI fails if CHANGELOG.md is not updated on PRs
+
+#### Bug Fixes
+- 
+
+## [0.1.1](https://github.com/SuperDuperDB/superduperdb/compare/0.0.20...0.1.0])    (2023-Feb-09)
+
+#### Changed defaults / behaviours
 
 - Support 3.10+ due to `dataclass` supported features
 - Updated the table creation method in MetaDataStore to improve compatibility across various databases.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
