### PR TITLE
Add ray serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### New Features & Functionality
 
 - Add Llama cpp model in extensions.
+- Basic Ray server support to server models on ray cluster
 - Simplify the testing of SQL databases using containerized databases
 - Integrate Monitoring(cadvisor/Prometheus) and Logging (promtail/Loki) with Grafana, in the `testenv`
 - Add `QueryModel` and `SequentialModel` to make chaining searches and models easier.

--- a/superduperdb/__main__.py
+++ b/superduperdb/__main__.py
@@ -3,9 +3,9 @@ import sys
 import click
 
 from superduperdb.cli import app, config, info
-from superduperdb.cli.serve import cdc, local_cluster, vector_search
+from superduperdb.cli.serve import cdc, local_cluster, ray_serve, vector_search
 
-__all__ = 'config', 'info', 'local_cluster', 'vector_search', 'cdc'
+__all__ = 'config', 'info', 'local_cluster', 'vector_search', 'cdc', 'ray_serve'
 
 
 def run():

--- a/superduperdb/backends/ray/serve.py
+++ b/superduperdb/backends/ray/serve.py
@@ -1,0 +1,45 @@
+import typing as t
+
+from ray import serve
+
+from superduperdb import CFG
+from superduperdb.components.model import _Predictor
+from superduperdb.server.app import SuperDuperApp
+
+# TODO: Try to get health endpoints from superduperdb app
+app = SuperDuperApp()
+
+
+def run(
+    model: str,
+    version: t.Optional[int] = None,
+    num_replicas: int = 1,
+    ray_actor_options: t.Dict = {},
+    route_prefix: str = '/',
+):
+    '''
+    Serve a superduperdb model on ray cluster
+    '''
+
+    @serve.deployment(ray_actor_options=ray_actor_options, num_replicas=num_replicas)
+    @serve.ingress(app.app)
+    class SuperDuperRayServe:
+        '''
+        A ray deployment which serves a superduperdb model with default ingress
+        '''
+
+        def __init__(self, model_identifier: str, version: t.Optional[int]):
+            from superduperdb.base.build import build_datalayer
+
+            db = build_datalayer(CFG)
+            self.model = db.load('model', model_identifier, version=version)
+
+        @app.app.post("/predict")
+        def predict(self, args: t.List, kwargs: t.Dict):
+            assert isinstance(self.model, _Predictor)
+            return self.model.predict_one(*args, **kwargs)
+
+    serve.run(
+        SuperDuperRayServe.bind(model_identifier=model, version=version),
+        route_prefix=route_prefix,
+    )

--- a/superduperdb/cli/serve.py
+++ b/superduperdb/cli/serve.py
@@ -1,4 +1,6 @@
+import json
 import subprocess
+import typing as t
 
 from . import command
 
@@ -34,3 +36,20 @@ def cdc():
     from superduperdb.cdc.app import app
 
     app.start()
+
+
+@command(help='Serve a model on ray')
+def ray_serve(
+    model: str,
+    version: t.Optional[int] = None,
+    ray_actor_options: str = '',
+    num_replicas: int = 1,
+):
+    from superduperdb.backends.ray.serve import run
+
+    run(
+        model=model,
+        version=version,
+        ray_actor_options=json.loads(ray_actor_options),
+        num_replicas=num_replicas,
+    )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description
Serves a model on ray cluster with ray serve

`SUPERDUPERDB_ARTIFACT_STORE="filesystem:///tmp/artifacts" SUPERDUPERDB_DATA_BACKEND='mongodb://superduper:superduper@mongodb:27017/test_db'  PYTHONPATH=./:.. python3 superduperdb/__main__.py ray-serve 'm1' --ray-actor-options '{"num_cpus": 0.2}' --num-replicas 1`

The above will serve the model on ray cluster 

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
