### PR TITLE
Add easy import decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI fails if CHANGELOG.md is not updated on PRs
 - Update Menu structure and renamed use-cases
 - Change and simplify the contract for writing new `_Predictor` descendants (`.predict_one`, `.predict`)
+- Create models directly by importing package from auto
 
 #### Bug Fixes
 - LLM CI random errors

--- a/superduperdb/ext/auto/__init__.py
+++ b/superduperdb/ext/auto/__init__.py
@@ -1,0 +1,52 @@
+import importlib
+import inspect
+import typing as t
+
+from superduperdb.components.schema import Schema
+
+
+def _decorator(f):
+    from superduperdb import Model
+
+    def dec(
+        *args,
+        identifier=None,
+        datatype=None,
+        model_update_kwargs: t.Optional[t.Dict] = None,
+        flatten: bool = False,
+        output_schema: t.Optional[Schema] = None,
+        **kwargs,
+    ):
+        model_update_kwargs = model_update_kwargs or {}
+        return Model(
+            identifier=identifier or f.__name__,
+            object=f(*args, **kwargs),
+            datatype=datatype,
+            flatten=flatten,
+            model_update_kwargs=model_update_kwargs,
+            output_schema=output_schema,
+        )
+
+    return dec
+
+
+class _Package:
+    def __init__(self, package_name: t.Optional[str] = None, package=None):
+        if package is None:
+            assert package_name is not None
+            self.package = importlib.import_module(package_name)
+        else:
+            self.package = package
+
+    def __getattr__(self, item):
+        object_ = getattr(self.package, item)
+        if inspect.ismodule(object_):
+            return _Package(package=object_)
+        return _decorator(object_)
+
+
+def __getattr__(name):
+    try:
+        return _Package(name)
+    except ImportError:
+        raise AttributeError(f"module {__file__} has no attribute {name}")

--- a/test/unittest/ext/test_auto.py
+++ b/test/unittest/ext/test_auto.py
@@ -1,0 +1,12 @@
+from superduperdb.components.model import ObjectModel
+
+
+def test_auto():
+    import torch as torch_native
+
+    from superduperdb.ext.auto import torch
+
+    m = torch.nn.Linear(2, 4, identifier='my-linear')
+
+    assert isinstance(m, ObjectModel)
+    assert isinstance(m.object, torch_native.nn.Module)


### PR DESCRIPTION
Make it possible to import `Model` instances directly from the Python ecosystem.