### PR TITLE
Fixed the bug where select in listener is modified in schedule_jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bug Fixes
 - LLM CI random errors
+- Fixed the bug where select in listener is modified in schedule_jobs.
 
 ## [0.1.1](https://github.com/SuperDuperDB/superduperdb/compare/0.0.20...0.1.0])    (2023-Feb-09)
 

--- a/superduperdb/base/serializable.py
+++ b/superduperdb/base/serializable.py
@@ -108,6 +108,9 @@ class Serializable(Leaf):
 
         return Document(asdict(self))
 
+    def copy(self):
+        return self.decode(self.encode())
+
 
 @dc.dataclass
 class Variable(Serializable):

--- a/superduperdb/base/serializable.py
+++ b/superduperdb/base/serializable.py
@@ -1,6 +1,7 @@
 import dataclasses as dc
 import importlib
 import typing as t
+from copy import deepcopy
 
 from superduperdb.base.config import BytesEncoding
 from superduperdb.base.leaf import Leaf
@@ -109,7 +110,7 @@ class Serializable(Leaf):
         return Document(asdict(self))
 
     def copy(self):
-        return self.decode(self.encode())
+        return deepcopy(self)
 
 
 @dc.dataclass

--- a/superduperdb/components/listener.py
+++ b/superduperdb/components/listener.py
@@ -140,7 +140,7 @@ class Listener(Component):
             self.model.predict(
                 X=self.key,
                 db=db,
-                select=self.select,
+                select=self.select.copy(),
                 dependencies=dependencies,
                 **(self.predict_kwargs or {}),
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

This bug leads to a mismatch in data volume when using the same database for building data and constructing vector_index indexes. 
This happens because during the prediction in `schedule_jobs`, the select is augmented with {$in: [id1, id, ...]} information. Additionally, during `max_chunk_size`, the `select` will only retain the ids of the last batch.

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
