### PR TITLE
Fix a minor bug in copy vectors for non document embedded table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize LLM fine-tuning
 
 #### Bug Fixes
+- Fix a minor bug in copy_vectors for outputs stored as seperate table.
 - Fixed the bug where select in listener is modified in schedule_jobs.
 - LLM CI random errors
 - VectorIndex schedule_jobs missing function.

--- a/superduperdb/vector_search/update_tasks.py
+++ b/superduperdb/vector_search/update_tasks.py
@@ -52,6 +52,8 @@ def copy_vectors(
     docs = db.select(select)
     docs = [doc.unpack() for doc in docs]
     key = vi.indexing_listener.key
+    if '_outputs' in key:
+        key = key.split('.')[1]
     model = vi.indexing_listener.model.identifier
     version = vi.indexing_listener.model.version
     # TODO: Refactor the below logic


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->
fix https://github.com/SuperDuperDB/superduperdb/issues/1834


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
