### PR TITLE
add nightly (pre-release) image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make lance upsert for added vectors
 
 #### New Features & Functionality
+- Add nightly image for pre-release testing in the cloud environment
 - Add requires functionality for all extension modules
 - CI fails if CHANGELOG.md is not updated on PRs
 - Update Menu structure and renamed use-cases

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ help: ## Display this help
 # The general flow is VERSION -> make new_release -> GITHUB_ACTIONS -> {make docker_push, ...}
 RELEASE_VERSION=$(shell cat VERSION)
 CURRENT_RELEASE=$(shell git describe --abbrev=0 --tags)
+CURRENT_COMMIT=$(shell git rev-parse --short HEAD)
+
 
 new_release: ## Release a new version of SuperDuperDB
 	@ if [[ -z "${RELEASE_VERSION}" ]]; then echo "VERSION is not set"; exit 1; fi
@@ -117,7 +119,7 @@ build_superduperdb: ## Build a minimal Docker image for general use
 	--build-arg BUILD_ENV="release"
 
 
-push_superduperdb: ## Push the superduperdb/superduperdb:latest image
+push_superduperdb: ## Push the superduperdb/superduperdb:<release> image
 	@echo "===> release superduperdb/superduperdb:$(RELEASE_VERSION:v%=%)"
 	docker push superduperdb/superduperdb:$(RELEASE_VERSION:v%=%)
 
@@ -133,6 +135,16 @@ testenv_image: ## Build a sandbox image
 	DOCKER_BUILDKIT=1 docker build . -f deploy/images/superduperdb/Dockerfile -t superduperdb/sandbox --progress=plain \
 		--build-arg BUILD_ENV="sandbox" \
 		--build-arg REQUIREMENTS_FILE="deploy/testenv/optional_requirements.txt" \
+
+
+build_nightly: ## Build superduperdb/nightly:<commit> image
+	echo "===> build superduperdb/superduperdb:$(CURRENT_COMMIT)"
+	docker build . -f ./deploy/images/superduperdb/Dockerfile -t superduperdb/nightly:$(CURRENT_COMMIT) --progress=plain --no-cache \
+	--build-arg BUILD_ENV="nightly"
+
+push_nightly: ## Push the superduperdb/nightly:<commit> image
+	@echo "===> release superduperdb/nightly:$(CURRENT_COMMIT)"
+	docker push superduperdb/nightly:$(CURRENT_COMMIT)
 
 
 ##@ Testing Environment

--- a/deploy/images/superduperdb/Dockerfile
+++ b/deploy/images/superduperdb/Dockerfile
@@ -86,35 +86,53 @@ ENV PYTHONDONTWRITEBYTECODE 1
 # Set python cache directory
 ENV PYTHONPYCACHEPREFIX "$HOME/.cache/cpython/"
 
-# ---------------
-# Build Sandbox
-# ---------------
+# -------------------------------
+# Build Sandbox (Development)
+# -------------------------------
 FROM base AS build_sandbox
 
-ARG REQUIREMENTS_FILE
-
+# Install the requirements. To be used in conjuction with "make testenv_init" for development.
+ONBUILD ARG REQUIREMENTS_FILE
 ONBUILD USER superduper
 ONBUILD COPY --chown=superduper ./pyproject.toml ${HOME}/superduperdb/pyproject.toml
 ONBUILD COPY --chown=superduper ./deploy/testenv/requirements.txt ${HOME}/superduperdb/requirements.txt
 ONBUILD COPY --chown=superduper ./Makefile ${HOME}/superduperdb/Makefile
 ONBUILD COPY --chown=superduper ./${REQUIREMENTS_FILE} ${HOME}/superduperdb/optional_requirements.txt
 ONBUILD WORKDIR ${HOME}/superduperdb
-ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install -r requirements.txt
-ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user  -r ./optional_requirements.txt
+ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user -r requirements.txt
+ONBUILD RUN --mount=type=cache,uid=1000,target=/home/superduper/.cache/pip python -m pip install --user -r ./optional_requirements.txt
 ONBUILD RUN make install-devkit
 
-# ---------------
-# Build Release
-# ---------------
+
+# -------------------------------
+# Build Nightly (Pre-Release)
+# -------------------------------
+FROM base AS build_nightly
+
+# Install the latest commit of the main branch in GitHub.
+ONBUILD WORKDIR ${HOME}/superduperdb
+ONBUILD RUN git clone -b main --single-branch  https://github.com/SuperDuperDB/superduperdb.git .
+ONBUILD RUN python -m pip install --user . \
+    # Install optional dependencies for testing
+    && python -m pip install --user -r deploy/testenv/optional_requirements.txt \
+    # Purge pip cache to reduce image size.
+    && pip cache purge
+
+
+# -------------------------------
+# Build Release (Production)
+# -------------------------------
 FROM base AS build_release
 
-ONBUILD ARG SUPERDUPERDB_EXTRAS=''
+# Install the latest release from pypi, including code from the GitHub branch of the release.
+# TODO: to be updated when we create the release branch.
 ONBUILD COPY --chown=superduper ${PWD}/examples ./examples
-# Drop cache to reduce image size.
 ONBUILD RUN python -m pip install --user superduperdb \
-    # Purge pip cache
+    # Purge pip cache to reduce image size.
     && pip cache purge
 ONBUILD WORKDIR ${HOME}/examples
+
+
 
 # ---------------
 # Select Build


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->

The `sandbox` image does not contain code, so it's inadequate for testing the cloud environment.

The `release` image is created after the release, so it's inadequate for testing the cloud environment.

For that, I 've create a `nightly` image that lies between the two. It should be regarded as a `pre-release` image, used for integration testing on the cloud environment.

## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes ##1905

## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
