### PR TITLE
remove the other ibis from the pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "ray[default]>=2.8.1",
     "uvicorn>=0.24.0",
     "fastapi>=0.103.2",
-    "ibis>=3.3.0",
     "ibis-framework>=5.1.0",
     "sqlalchemy>=2.0.28",
     "python-magic"


### PR DESCRIPTION
hello, I believe the use of `ibis` -- a Jinja templating framework thing -- and not `ibis-framework`, the portable Python dataframe library

this just removes that line, not sure if it's sufficient

<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit-testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
