### PR TITLE
Update do_insert in MongoDB tab 

### DIFF
--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -17,16 +17,15 @@
    "outputs": [],
    "source": [
     "# <tab: MongoDB>\n",
-    "from superduperdb import Document\n",
+    "from superduperdb import Document, DataType\n",
     "\n",
-    "def do_insert(data):\n",
-    "    schema = None\n",
+    "def do_insert(data, schema = None):\n",
     "    \n",
     "    \n",
     "    if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
     "        data = [Document({'x': x}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
-    "    elif schema is None and datatype is not None and isintance():\n",
+    "    elif schema is None and datatype is not None and isinstance(datatype, DataType):\n",
     "        data = [Document({'x': datatype(x)}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
     "    else:\n",
@@ -50,9 +49,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
-   "name": "python3"
+   "name": ".venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -64,7 +63,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -21,7 +21,6 @@
     "\n",
     "def do_insert(data, schema = None):\n",
     "    \n",
-    "    \n",
     "    if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
     "        data = [Document({'x': x}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
@@ -49,9 +48,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": ".venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -63,7 +62,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

This update introduces two significant improvements to the `do_insert` function within the MongoDB tab of the `superduperdb` package:

1. Previously, the datatype check within the conditional statements was incomplete, leading to potential issues when non-string data types were passed. I've fixed this by importing the `DataType` class and explicitly checking if the `datatype` is an instance of `DataType`. 

2.  I've modified the function signature of `do_insert` to include `schema` as an optional parameter with a default value of `None`. 
## Related Issues

[TEST-USE] Transfer learning #1967

## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make unit-testing` and `make integration-testing` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?