### PR TITLE
Reusable snippets/update insert data to insert labeled data

### DIFF
--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -21,15 +21,26 @@
     "\n",
     "def do_insert(data, schema = None):\n",
     "    \n",
-    "    if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
-    "        data = [Document({'x': x}) for x in data]\n",
-    "        db.execute(table_or_collection.insert_many(data))\n",
-    "    elif schema is None and datatype is not None and isinstance(datatype, DataType):\n",
-    "        data = [Document({'x': datatype(x)}) for x in data]\n",
-    "        db.execute(table_or_collection.insert_many(data))\n",
-    "    else:\n",
-    "        data = [Document({'x': x}) for x in data]\n",
-    "        db.execute(table_or_collection.insert_many(data, schema='my_schema'))"
+    "    if isinstance(data[0], dict):  \n",
+    "        if schema is None and (datatype is None or isinstance(datatype, str)):\n",
+    "            data = [Document({'x': x['x'], 'y': x['y']}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data))\n",
+    "        elif schema is None and datatype is not None and isinstance(datatype, DataType):\n",
+    "            data = [Document({'x': datatype(x['x']), 'y': x['y']}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data))\n",
+    "        else:\n",
+    "            data = [Document({'x': x['x'], 'y': x['y']}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data, schema=schema))\n",
+    "    else:       \n",
+    "        if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
+    "            data = [Document({'x': x}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data))\n",
+    "        elif schema is None and datatype is not None and isinstance(datatype, DataType):\n",
+    "            data = [Document({'x': datatype(x)}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data))\n",
+    "        else:\n",
+    "            data = [Document({'x': x}) for x in data]\n",
+    "            db.execute(table_or_collection.insert_many(data, schema=schema))"
    ]
   },
   {
@@ -42,15 +53,18 @@
     "from superduperdb import Document\n",
     "\n",
     "def do_insert(data):\n",
-    "    db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x}) for idx, x in enumerate(data)]))"
+    "    if isinstance(data[0], dict):\n",
+    "        db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x['x'], 'y': x['y']}) for idx, x in enumerate(data)]))\n",
+    "    else:\n",
+    "        db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x}) for idx, x in enumerate(data)]))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
-   "name": "python3"
+   "name": ".venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -62,7 +76,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -62,9 +62,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": ".venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -76,7 +76,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -17,16 +17,15 @@
    "outputs": [],
    "source": [
     "# <tab: MongoDB>\n",
-    "from superduperdb import Document\n",
+    "from superduperdb import Document, DataType\n",
     "\n",
-    "def do_insert(data):\n",
-    "    schema = None\n",
+    "def do_insert(data, schema = None):\n",
     "    \n",
     "    \n",
     "    if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
     "        data = [Document({'x': x}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
-    "    elif schema is None and datatype is not None and isintance():\n",
+    "    elif schema is None and datatype is not None and isinstance(datatype, DataType):\n",
     "        data = [Document({'x': datatype(x)}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
     "    else:\n",
@@ -50,9 +49,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
-   "name": "python3"
+   "name": ".venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -64,7 +63,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.ipynb
@@ -21,7 +21,6 @@
     "\n",
     "def do_insert(data, schema = None):\n",
     "    \n",
-    "    \n",
     "    if schema is None and (datatype is None  or isinstance(datatype, str)) :\n",
     "        data = [Document({'x': x}) for x in data]\n",
     "        db.execute(table_or_collection.insert_many(data))\n",
@@ -49,9 +48,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": ".venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -63,7 +62,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/hr/content/docs/reusable_snippets/insert_data.md
+++ b/docs/hr/content/docs/reusable_snippets/insert_data.md
@@ -15,19 +15,28 @@ In order to create data, we need to create a `Schema` for encoding our special `
         ```python
         from superduperdb import Document
         
-        def do_insert(data):
-            schema = None
+        def do_insert(data, schema = None):
             
-            
-            if schema is None and (datatype is None  or isinstance(datatype, str)) :
-                data = [Document({'x': x}) for x in data]
-                db.execute(table_or_collection.insert_many(data))
-            elif schema is None and datatype is not None and isintance():
-                data = [Document({'x': datatype(x)}) for x in data]
-                db.execute(table_or_collection.insert_many(data))
-            else:
-                data = [Document({'x': x}) for x in data]
-                db.execute(table_or_collection.insert_many(data, schema='my_schema'))        
+            if isinstance(data[0], dict):  
+                if schema is None and (datatype is None or isinstance(datatype, str)):
+                    data = [Document({'x': x['x'], 'y': x['y']}) for x in data]
+                    db.execute(table_or_collection.insert_many(data))
+                elif schema is None and datatype is not None and isinstance(datatype, DataType):
+                    data = [Document({'x': datatype(x['x']), 'y': x['y']}) for x in data]
+                    db.execute(table_or_collection.insert_many(data))
+                else:
+                    data = [Document({'x': x['x'], 'y': x['y']}) for x in data]
+                    db.execute(table_or_collection.insert_many(data, schema=schema))
+            else:       
+                if schema is None and (datatype is None  or isinstance(datatype, str)) :
+                    data = [Document({'x': x}) for x in data]
+                    db.execute(table_or_collection.insert_many(data))
+                elif schema is None and datatype is not None and isinstance(datatype, DataType):
+                    data = [Document({'x': datatype(x)}) for x in data]
+                    db.execute(table_or_collection.insert_many(data))
+                else:
+                    data = [Document({'x': x}) for x in data]
+                    db.execute(table_or_collection.insert_many(data, schema=schema))     
         ```
     </TabItem>
     <TabItem value="SQL" label="SQL" default>
@@ -35,7 +44,10 @@ In order to create data, we need to create a `Schema` for encoding our special `
         from superduperdb import Document
         
         def do_insert(data):
-            db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x}) for idx, x in enumerate(data)]))        
+            if isinstance(data[0], dict):
+                db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x['x'], 'y': x['y']}) for idx, x in enumerate(data)]))
+            else:
+                db.execute(table_or_collection.insert([Document({'id': str(idx), 'x': x}) for idx, x in enumerate(data)]))        
         ```
     </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

Updated the do_insert() method such that if the data is labeled data or list of dicts that contains x and y fields can be inserted in to the db's collection or table.


## Related Issues

[TEST-USE] Transfer learning #1967

## Checklist

- [x] Is this code covered by new or existing unit tests or integration tests?
- [x] Did you run `make unit-testing` and `make integration-testing` successfully?
- [x] Do new classes, functions, methods and parameters all have docstrings?
- [x] Were existing docstrings updated, if necessary?
- [x] Was external documentation updated, if necessary?
