### PR TITLE
Add shortcut to `db.execute`

### DIFF
--- a/superduperdb/backends/base/query.py
+++ b/superduperdb/backends/base/query.py
@@ -368,6 +368,10 @@ class Query(_BaseQuery):
         pass
 
     def execute(self, db=None):
+        self.db = db or self.db
+        return self.db.execute(self)
+
+    def do_execute(self, db=None):
         """Execute the query.
 
         This methold will first create the table if it does not exist and then

--- a/superduperdb/backends/ibis/query.py
+++ b/superduperdb/backends/ibis/query.py
@@ -203,7 +203,7 @@ class IbisQuery(Query):
                 *self.parts[1:],
             ],
         )
-        result = query.execute(db=self.db)
+        result = query.do_execute(db=self.db)
         result.scores = similar_scores
         return result
 
@@ -287,7 +287,7 @@ class IbisQuery(Query):
         )
 
     def _execute(self, parent, method='encode'):
-        output = super()._execute(parent, method=method).execute()
+        output = super()._execute(parent, method=method).do_execute()
         assert isinstance(output, pandas.DataFrame)
         output = output.to_dict(orient='records')
         component_table = self.db.tables[self.identifier]

--- a/superduperdb/backends/mongodb/query.py
+++ b/superduperdb/backends/mongodb/query.py
@@ -161,7 +161,7 @@ class MongoQuery(Query):
             identifier=self.identifier,
             parts=[(self.parts[1][0], tuple(find_args), find_kwargs), *self.parts[2:]],
         )
-        result = q.execute(db=self.db)
+        result = q.do_execute(db=self.db)
         result.scores = similar_scores
         return result
 
@@ -186,7 +186,7 @@ class MongoQuery(Query):
         if range:
             parent_query = parent_query.limit(range)
 
-        relevant_ids = [str(r['_id']) for r in parent_query.execute()]
+        relevant_ids = [str(r['_id']) for r in parent_query.do_execute()]
 
         similar_ids, scores = self.db.select_nearest(
             like=r,

--- a/superduperdb/base/datalayer.py
+++ b/superduperdb/base/datalayer.py
@@ -299,7 +299,7 @@ class Datalayer:
         if query.type == 'update':
             return self._update(query, *args, **kwargs)
 
-        return query.execute(self)
+        return query.do_execute(self)
 
         raise TypeError(
             f'Wrong type of {query}; '
@@ -316,7 +316,7 @@ class Datalayer:
 
         :param delete: The delete query object specifying the data to be deleted.
         """
-        result = delete.execute(self)
+        result = delete.do_execute(self)
         if refresh and not self.cdc.running:
             return result, self.refresh_after_delete(delete, ids=result)
         return result, None
@@ -339,7 +339,7 @@ class Datalayer:
             if random.random() < s.CFG.fold_probability:
                 r['_fold'] = 'valid'
 
-        inserted_ids = insert.execute(self)
+        inserted_ids = insert.do_execute(self)
 
         cdc_status = self.cdc.running or s.CFG.cluster.cdc.uri is not None
 
@@ -358,7 +358,7 @@ class Datalayer:
 
         :param select: The select query object specifying the data to be retrieved.
         """
-        return select.execute(db=self)
+        return select.do_execute(db=self)
 
     def refresh_after_delete(
         self,
@@ -414,7 +414,7 @@ class Datalayer:
         :param write: The update query object specifying the data to be written.
         :param refresh: Boolean indicating whether to refresh the task group on write.
         """
-        write_result, updated_ids, deleted_ids = write.execute(self)
+        write_result, updated_ids, deleted_ids = write.do_execute(self)
 
         cdc_status = self.cdc.running or s.CFG.cluster.cdc.uri is not None
         if refresh:
@@ -453,7 +453,7 @@ class Datalayer:
         :return: Tuple containing the updated IDs and the refresh result if
                  performed.
         """
-        updated_ids = update.execute(self)
+        updated_ids = update.do_execute(self)
 
         cdc_status = self.cdc.running or s.CFG.cluster.cdc.uri is not None
         if refresh:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -161,7 +161,7 @@ def add_random_data_to_sql_db(
         fold = 'valid' if fold else 'train'
 
         data.append(Document({'id': str(i), 'x': x, 'y': y, 'z': z, '_fold': fold}))
-    db[table_name].insert(data).execute()
+    db[table_name].insert(data).do_execute()
 
 
 def add_random_data_to_mongo_db(

--- a/test/unittest/backends/mongodb/test_query.py
+++ b/test/unittest/backends/mongodb/test_query.py
@@ -53,8 +53,8 @@ def test_mongo_without_schema(db):
         MongoQuery(collection_name).insert_many(data),
     )
     collection = MongoQuery(collection_name)
-    r = collection.find_one().execute(db)
-    rs = list(collection.find().execute(db))
+    r = collection.find_one().do_execute(db)
+    rs = list(collection.find().do_execute(db))
 
     rs = sorted(rs, key=lambda x: x['id'])
 
@@ -100,8 +100,8 @@ def test_mongo_schema(db, schema):
     db.execute(
         MongoQuery(db=db, identifier=collection_name).insert_many(data),
     )
-    r = db[collection_name].find_one().execute()
-    rs = list(db[collection_name].find().execute())
+    r = db[collection_name].find_one().do_execute()
+    rs = list(db[collection_name].find().do_execute())
 
     rs = sorted(rs, key=lambda x: x['id'])
 

--- a/test/unittest/base/test_document.py
+++ b/test/unittest/base/test_document.py
@@ -194,6 +194,6 @@ def test_column_encoding(db):
             Document({'x': 1, 'y': 2, 'img': img}),
             Document({'x': 3, 'y': 4, 'img': img}),
         ]
-    ).execute()
+    ).do_execute()
 
-    db['test'].select("x", "y", "img").execute()
+    db['test'].select("x", "y", "img").do_execute()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
