### PR TITLE
`db.execute(query)` alternative.

### DIFF
--- a/superduperdb/backends/base/query.py
+++ b/superduperdb/backends/base/query.py
@@ -368,6 +368,10 @@ class Query(_BaseQuery):
         pass
 
     def execute(self, db=None):
+        """Execute the query with query.execute() notation.
+
+        :param db: Datalayer instance.
+        """
         self.db = db or self.db
         return self.db.execute(self)
 
@@ -574,7 +578,7 @@ class PredictOne(_BaseQuery):
     args: t.Sequence = dc.field(default_factory=list)
     kwargs: t.Dict = dc.field(default_factory=dict)
 
-    def execute(self, db):
+    def do_execute(self, db):
         """Execute the query.
 
         :param db: The datalayer instance

--- a/test/unittest/base/test_document.py
+++ b/test/unittest/base/test_document.py
@@ -177,6 +177,7 @@ def test_column_encoding(db):
     schema = Schema(
         'test',
         fields={
+            'id': int,
             'x': int,
             'y': int,
             'img': pil_image,
@@ -191,8 +192,8 @@ def test_column_encoding(db):
 
     db['test'].insert(
         [
-            Document({'x': 1, 'y': 2, 'img': img}),
-            Document({'x': 3, 'y': 4, 'img': img}),
+            Document({'id': 1, 'x': 1, 'y': 2, 'img': img}),
+            Document({'id': 2, 'x': 3, 'y': 4, 'img': img}),
         ]
     ).execute()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
