### PR TITLE
Add devkit to dependency installation (#2134)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ python3 -m pip install --upgrade pip-tools
 # Install the superduperdb project in editable mode along with the developer tools
 python3 -m pip install -e '.'
 python3 -m pip install -r deploy/installations/testenv_requirements.txt
+make install_devkit
 ```
 
 (Optional) build the docker development environment:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

Add `make install_devkit` command to documentation of dependency installation in [CONTRIBUTING.md](https://github.com/SuperDuperDB/superduperdb/blob/main/CONTRIBUTING.md).


## Related Issues

Doc devkit installation (fix #2134)


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments

- Checklist does not apply for this change.