### PR TITLE
Add additional options to local-cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add and update docstrings in component classes and methods.
 - Changed the rest implementation to use new serialization
 - Remove unused deadcode from the project
-- Auto wrap insert documents as Document
+- Auto wrap insert documents as Document instances
 - Changed the rest implementation to use the new serialization
 - Mask special character keys in mongodb queries
 

--- a/superduperdb/cli/serve.py
+++ b/superduperdb/cli/serve.py
@@ -5,18 +5,32 @@ from . import command
 
 
 @command(help='Start local cluster: server, ray and change data capture')
-def local_cluster(action: str, notebook_token: t.Optional[str] = None):
+def local_cluster(
+    action: str,
+    notebook_token: t.Optional[str] = None,
+    num_workers: int = 0,
+    attach: bool = True,
+    cdc: bool = False,
+):
     """Start local cluster: server, ray and change data capture.
 
     :param action: Action to perform (up, down, attach).
     :param notebook_token: Notebook token.
+    :param num_workers: Number of workers.
+    :param attach: Attach to the cluster.
+    :param cdc: Start change data capture or not.
     """
     from superduperdb.server.cluster import attach_cluster, down_cluster, up_cluster
 
     action = action.lower()
 
     if action == 'up':
-        up_cluster(notebook_token=notebook_token)
+        up_cluster(
+            notebook_token=notebook_token,
+            num_workers=num_workers,
+            attach=attach,
+            cdc=cdc,
+        )
     elif action == 'down':
         down_cluster()
     elif action == 'attach':


### PR DESCRIPTION
This was important for local-testing on Mac. On Mac M1-3, it seems not to be an option to have multiple workers. 
This is fine for local testing.