### PR TITLE
Docs modal change from v0.1 to v0.2

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -348,7 +348,7 @@ const config = {
       ],
       announcementBar: {
         id: 'support_us',
-        content: '🔮 We officially released v0.1 on Github! 🔮',
+        content: '🔮 We officially released v0.2 on Github! Check it out! 🔮',
         backgroundColor: '#7628f8',
         textColor: '#fff',
         isCloseable: true,


### PR DESCRIPTION
![image](https://github.com/SuperDuperDB/superduperdb/assets/9541936/6ab0a69a-252b-47c3-8717-a51a8b410b60)

Just changing the top modal of the docs to v.02