### PR TITLE
Feat/artifact/remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added templates directory with OSS templates
 - Qdrant vector search support
 - Add placeholder for web app link in Application
+- Add support for remote artifacts
 
 #### Bug Fixes
 

--- a/superduper/components/component.py
+++ b/superduper/components/component.py
@@ -340,15 +340,31 @@ class Component(Leaf):
         if db is not None:
             for blob in os.listdir(path + '/' + 'blobs'):
                 with open(path + '/blobs/' + blob, 'rb') as f:
-                    bytes = f.read()
-                    db.artifact_store.put_bytes(bytes, blob)
+                    data = f.read()
+                    db.artifact_store.put_bytes(data, blob)
 
             out = Document.decode(config_object, db=db).unpack()
         else:
 
-            def load_blob(blob):
-                with open(path + '/blobs/' + blob, 'rb') as f:
-                    return f.read()
+            def load_blob(blob, loader=None):
+                from superduper.misc.download import hash_uri
+
+                def _read_blob(blob_path):
+                    with open(blob_path, 'rb') as f:
+                        return f.read()
+
+                key = hash_uri(blob)
+                cached_path = path + '/blobs/' + key
+                if os.path.exists(cached_path):
+                    return _read_blob(cached_path)
+                elif loader.is_uri(blob):
+                    with open(path + '/blobs/' + key, 'wb') as f:
+                        data = loader(blob)
+                        f.write(data)
+                        return data
+                else:
+                    blob_path = path + '/blobs/' + blob
+                    return _read_blob(blob_path=blob_path)
 
             getters = {'blob': load_blob}
 

--- a/superduper/components/component.py
+++ b/superduper/components/component.py
@@ -347,17 +347,17 @@ class Component(Leaf):
         else:
 
             def load_blob(blob, loader=None):
-                from superduper.misc.download import hash_uri
+                from superduper.misc.hash import hash_string
 
                 def _read_blob(blob_path):
                     with open(blob_path, 'rb') as f:
                         return f.read()
 
-                key = hash_uri(blob)
+                key = hash_string(blob)[:32]  # uuid length
                 cached_path = path + '/blobs/' + key
                 if os.path.exists(cached_path):
                     return _read_blob(cached_path)
-                elif loader.is_uri(blob):
+                elif loader and loader.is_uri(blob):
                     with open(path + '/blobs/' + key, 'wb') as f:
                         data = loader(blob)
                         f.write(data)

--- a/superduper/misc/download.py
+++ b/superduper/misc/download.py
@@ -1,4 +1,3 @@
-import hashlib
 import re
 import signal
 import sys
@@ -510,17 +509,3 @@ class DownloadFiles(Model):
         if self.postprocess:
             results = [self.postprocess(r) for r in results]
         return results
-
-
-def hash_uri(uri: str) -> str:
-    """Return a hash for uri.
-
-    :param uri: uri string.
-    """
-    uri_bytes = uri.encode('utf-8')
-    hash_object = hashlib.sha256()
-    hash_object.update(uri_bytes)
-
-    hash_hex = hash_object.hexdigest()[:32]
-
-    return hash_hex


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

fix https://github.com/superduper-io/superduper/issues/2438

Support remote uri in blobs and uri
This was part of supporting snowflake services.

We need to support a superduper serialised which consists blobs with remote uri like s3,file:// etc
when this serialised document is decoded we download the remote blobs and replace the uri with local reference.
<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
