### PR TITLE
_OpenAI(APIBaseModel)  add `default_headers`   in `client_kwargs`

### DIFF
--- a/plugins/openai/superduper_openai/model.py
+++ b/plugins/openai/superduper_openai/model.py
@@ -59,6 +59,7 @@ class _OpenAI(APIBaseModel):
             self.client_kwargs['api_key'] = self.openai_api_key
         if self.openai_api_base is not None:
             self.client_kwargs['base_url'] = self.openai_api_base
+            self.client_kwargs['default_headers'] = self.openai_api_base
 
         # dall-e is not currently included in list returned by OpenAI model endpoint
         if self.model not in (


### PR DESCRIPTION
Added `default_headers` as available key in `client_kwargs`

 

## Description

Sometimes custom OpenAI compatible endpoints require specific headers. 

This is supported in the OpenAI library via the `default_headers` but is it not available in the super_duper adapter.

This was tested for connecting via local [TGI](https://github.com/huggingface/text-generation-inference) server that is serving OpenAI compatible API.

```python
from superduper_openai import OpenAIChatCompletion

llm = OpenAIChatCompletion(
    identifier="llm",
    model='meta-llama/Meta-Llama-3.1-8B-Instruct',
    client_kwargs={
        "base_url": "http://127.0.0.1:8080/v1",
        "api_key" : "NA",
        "default_headers": {"Content-Type": "application/json"}
    }
)
print(llm.predict("Tell me a joke"))

```
It does not brake existing functionality.


## Related Issues
NA

 
## Checklist

- [] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
