### PR TITLE
Fix the query parser incompatibility with '.' symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed atlas vector search
 - Fix the bug where shared artifacts are deleted when removing a component.
 - Fix compatibility issues with the latest version of pymongo.
+- Fix the query parser incompatibility with '.' symbol.
 
 #### New Features & Functionality
 
@@ -325,3 +326,5 @@ Test release before v0.2
 ## [0.0.5](https://github.com/superduper-io/superduper/compare/0.0.5...0.0.4])      (2023-Aug-15)
 
 ## 0.0.4      (2023-Aug-03)
+
+

--- a/superduper/backends/base/query.py
+++ b/superduper/backends/base/query.py
@@ -712,17 +712,23 @@ class Query(_BaseQuery):
 
 
 def _parse_query_part(part, documents, query, builder_cls, db=None):
-    if '.' in CFG.output_prefix and part.startswith(CFG.output_prefix):
-        rest_part = part[len(CFG.output_prefix) :].split('.')
-        table = f'{CFG.output_prefix}{rest_part[0]}'
-        part = rest_part[1:]
-
+    if part.startswith(CFG.output_prefix):
+        predict_id = part[len(CFG.output_prefix) :].split('.')[0]
+        table = f'{CFG.output_prefix}{predict_id}'
+        rest_part = part[len(table) + 1 :]
     else:
-        table = part.split('.')[0]
-        part = part.split('.')[1:]
+        table = part.split('.', 1)[0]
+        rest_part = part[len(table) + 1 :]
+
+    # The format of the rest part should be a chain of '.method(args, kwargs)'
+    parts = re.findall(r'\.([a-zA-Z0-9_]+)(\(.*?\))?', "." + rest_part)
+    recheck_part = ".".join(p[0] + p[1] for p in parts)
+    if recheck_part != rest_part:
+        raise ValueError(f'Invalid query part: {part} != {recheck_part}')
 
     current = builder_cls(table=table, parts=(), db=db)
-    for comp in part:
+    for part in parts:
+        comp = part[0] + part[1]
         match = re.match(r'^([a-zA-Z0-9_]+)\((.*)\)$', comp)
         if match is None:
             current = getattr(current, comp)

--- a/test/unittest/backends/base/test_query.py
+++ b/test/unittest/backends/base/test_query.py
@@ -1,5 +1,7 @@
 from test.utils.database import query as query_utils
 
+from superduper import Document
+
 
 def test_insert(db):
     query_utils.test_insert(db)
@@ -31,3 +33,20 @@ def test_model(db):
 
 def test_model_query():
     query_utils.test_model_query()
+
+
+def test_model_query_serialization():
+    query = {
+        "query": 'modela.predict("<var:abc>", documents[0], '
+        'condition={"uri": "123.PDF"})',
+        '_variables': {'abc': "ABC"},
+        "documents": [{"a": "a"}],
+        "_builds": {},
+        "_files": {},
+        "_path": "superduper.backends.base.query.parse_query",
+    }
+
+    decode_query = Document.decode(query)
+    assert decode_query.parts[0][0] == 'predict'
+    assert decode_query.parts[0][1] == ("ABC", {'a': 'a'})
+    assert decode_query.parts[0][2] == {'condition': {'uri': '123.PDF'}}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
