### PR TITLE
Feature/2211 graceful updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### New Features & Functionality
 
 - Streamlit component and server
+- Graceful updates when making incremental changes
 
 #### Bug Fixes
 

--- a/plugins/mongodb/superduper_mongodb/metadata.py
+++ b/plugins/mongodb/superduper_mongodb/metadata.py
@@ -363,14 +363,21 @@ class MongoMetaDataStore(MetaDataStore):
     def _replace_object(
         self,
         info: t.Dict[str, t.Any],
-        identifier: str,
-        type_id: str,
-        version: int,
+        identifier: str | None = None,
+        type_id: str | None = None,
+        version: int | None = None,
+        uuid: str | None = None,
     ) -> None:
-        self.component_collection.replace_one(
-            {'identifier': identifier, 'type_id': type_id, 'version': version},
-            info,
-        )
+        if uuid:
+            return self.component_collection.replace_one({'uuid': uuid}, info)
+        else:
+            assert type_id, 'type_id cannot be False in replace'
+            assert identifier, "identifier cannot be False in replace"
+            assert version is not None, 'version cannot be None in replace'
+            self.component_collection.replace_one(
+                {'identifier': identifier, 'type_id': type_id, 'version': version},
+                info,
+            )
 
     def _update_object(
         self,

--- a/plugins/mongodb/superduper_mongodb/query.py
+++ b/plugins/mongodb/superduper_mongodb/query.py
@@ -126,7 +126,7 @@ class MongoQuery(Query):
     def _create_table_if_not_exists(self):
         return
 
-    def dict(self, metadata: bool = True, defaults: bool = True):
+    def dict(self, metadata: bool = True, defaults: bool = True, uuid: bool = True):
         """Return the query as a dictionary."""
         r = super().dict()
         r['documents'] = list(map(_serialize_special_character, r['documents']))

--- a/plugins/sqlalchemy/superduper_sqlalchemy/metadata.py
+++ b/plugins/sqlalchemy/superduper_sqlalchemy/metadata.py
@@ -472,19 +472,31 @@ class SQLAlchemyMetadata(MetaDataStore):
             )
             session.execute(stmt)
 
-    def _replace_object(self, info, identifier, type_id, version):
+    def _replace_object(self, info, identifier: str | None = None, type_id: str | None = None, version: int | None = None, uuid: str | None = None):
         info = self._refactor_component_info(info)
-        with self.session_context() as session:
-            stmt = (
-                self.component_table.update()
-                .where(
-                    self.component_table.c.type_id == type_id,
-                    self.component_table.c.identifier == identifier,
-                    self.component_table.c.version == version,
+
+        if uuid is None:
+            with self.session_context() as session:
+                stmt = (
+                    self.component_table.update()
+                    .where(
+                        self.component_table.c.type_id == type_id,
+                        self.component_table.c.identifier == identifier,
+                        self.component_table.c.version == version,
+                    )
+                    .values(**info)
                 )
-                .values(**info)
-            )
-            session.execute(stmt)
+                session.execute(stmt)
+        else:
+            with self.session_context() as session:
+                stmt = (
+                    self.component_table.update()
+                    .where(
+                        self.component_table.c.uuid == uuid
+                    )
+                    .values(**info)
+                )
+                session.execute(stmt)
 
     def show_cdc_tables(self):
         """Show tables to be consumed with cdc."""

--- a/plugins/sqlalchemy/superduper_sqlalchemy/metadata.py
+++ b/plugins/sqlalchemy/superduper_sqlalchemy/metadata.py
@@ -472,7 +472,14 @@ class SQLAlchemyMetadata(MetaDataStore):
             )
             session.execute(stmt)
 
-    def _replace_object(self, info, identifier: str | None = None, type_id: str | None = None, version: int | None = None, uuid: str | None = None):
+    def _replace_object(
+        self,
+        info,
+        identifier: str | None = None,
+        type_id: str | None = None,
+        version: int | None = None,
+        uuid: str | None = None,
+    ):
         info = self._refactor_component_info(info)
 
         if uuid is None:
@@ -491,9 +498,7 @@ class SQLAlchemyMetadata(MetaDataStore):
             with self.session_context() as session:
                 stmt = (
                     self.component_table.update()
-                    .where(
-                        self.component_table.c.uuid == uuid
-                    )
+                    .where(self.component_table.c.uuid == uuid)
                     .values(**info)
                 )
                 session.execute(stmt)

--- a/superduper/backends/base/metadata.py
+++ b/superduper/backends/base/metadata.py
@@ -437,6 +437,8 @@ class MetaDataStore(ABC):
         :param version: version of object
         """
         if version is None and uuid is None:
+            assert isinstance(type_id, str)
+            assert isinstance(identifier, str)
             version = self.get_latest_version(type_id, identifier)
         return self._replace_object(
             info=info,

--- a/superduper/backends/base/metadata.py
+++ b/superduper/backends/base/metadata.py
@@ -410,15 +410,23 @@ class MetaDataStore(ABC):
         pass
 
     @abstractmethod
-    def _replace_object(self, info, identifier, type_id, version):
+    def _replace_object(
+        self,
+        info,
+        identifier: str | None = None,
+        type_id: str | None = None,
+        version: int | None = None,
+        uuid: str | None = None,
+    ):
         pass
 
     def replace_object(
         self,
         info: t.Dict[str, t.Any],
-        identifier: str,
-        type_id: str,
-        version: t.Optional[int] = None,
+        identifier: str | None = None,
+        type_id: str | None = None,
+        version: int | None = None,
+        uuid: str | None = None,
     ) -> None:
         """
         Replace an object in the metadata store.
@@ -428,13 +436,14 @@ class MetaDataStore(ABC):
         :param type_id: type of object
         :param version: version of object
         """
-        if version is not None:
+        if version is None and uuid is None:
             version = self.get_latest_version(type_id, identifier)
         return self._replace_object(
             info=info,
             identifier=identifier,
             type_id=type_id,
             version=version,
+            uuid=uuid,
         )
 
     @abstractmethod

--- a/superduper/backends/base/query.py
+++ b/superduper/backends/base/query.py
@@ -365,6 +365,16 @@ class Query(_BaseQuery):
         """
         pass
 
+    def __eq__(self, value):
+        if not isinstance(value, Query):
+            return False
+        left = self.dict()
+        right = value.dict()
+        for k in left:
+            if left[k] != right[k]:
+                return False
+        return True
+
     def dict(self, metadata: bool = True, defaults: bool = True):
         """Return the query as a dictionary."""
         query, documents = self._dump_query()

--- a/superduper/backends/base/query.py
+++ b/superduper/backends/base/query.py
@@ -365,17 +365,13 @@ class Query(_BaseQuery):
         """
         pass
 
-    def __eq__(self, value):
-        if not isinstance(value, Query):
-            return False
-        left = self.dict()
-        right = value.dict()
-        for k in left:
-            if left[k] != right[k]:
-                return False
-        return True
-
-    def dict(self, metadata: bool = True, defaults: bool = True):
+    def dict(
+        self,
+        metadata: bool = True,
+        defaults: bool = True,
+        uuid: bool = True,
+        refs: bool = False,
+    ):
         """Return the query as a dictionary."""
         query, documents = self._dump_query()
         documents = [Document(r) for r in documents]

--- a/superduper/base/apply.py
+++ b/superduper/base/apply.py
@@ -134,7 +134,7 @@ def _apply(
     if already_exists:
         current = db.load(object.type_id, object.identifier)
         diff = current.dict().diff(serialized)
-        diff = Document({k: v for k, v in diff.items() if k not in {'uuid', 'version'}})
+        diff = Document({k: v for k, v in diff.items() if k not in {'uuid', 'version', 'status'}})
         if not diff:
             return [], job_events
 

--- a/superduper/base/apply.py
+++ b/superduper/base/apply.py
@@ -1,0 +1,251 @@
+import click
+import networkx
+from superduper import logging
+import typing as t
+
+from superduper.base.constant import KEY_BUILDS
+from superduper.base.event import Create, Signal
+from superduper.components.component import Status
+from superduper.misc.special_dicts import recursive_update
+from superduper import Component
+
+if t.TYPE_CHECKING:
+    from superduper.base.datalayer import Datalayer
+    from superduper.base.event import Job
+
+
+def apply(
+    db: 'Datalayer',
+    object: t.Union['Component', t.Sequence[t.Any], t.Any],
+    force: bool | None = None,
+):
+    """
+    Add functionality in the form of components.
+
+    Components are stored in the configured artifact store
+    and linked to the primary database through metadata.
+
+    :param db: Datalayer instance
+    :param object: Object to be stored.
+    :param force: List of jobs which should execute before component
+                            initialization begins.
+    :return: Tuple containing the added object(s) and the original object(s).
+    """
+    if force is None:
+        force = db.cfg.force_apply
+
+    if not isinstance(object, Component):
+        raise ValueError('Only components can be applied')
+
+    # This populates the component with data fetched
+    # from `db` if necessary
+    # We need pre as well as post-create, since the order
+    # between parents and children are reversed in each
+    # sometimes parents might need to grab things from children
+    # and vice-versa
+    object.pre_create(db)
+
+    # context allows us to track the origin of the component creation
+    create_events, job_events = _apply(
+        db=db,
+        object=object,
+        context=object.uuid,
+        job_events=[],
+    )
+    # this flags that the context is not needed anymore
+    if not create_events:
+        return object
+
+    # TODO for some reason the events get created multiple times
+    # we need to fix that to prevent inefficiencies
+    unique_create_ids = []
+    unique_create_events = []
+    for e in create_events:
+        if e.component['uuid'] not in unique_create_ids:
+            unique_create_ids.append(e.component['uuid'])
+            unique_create_events.append(e)
+
+    unique_job_ids = []
+    unique_job_events = []
+    for e in job_events:
+        if e.job_id not in unique_job_ids:
+            unique_job_ids.append(e.job_id)
+            unique_job_events.append(e)
+
+    logging.info('Here are the CREATION EVENTS:')
+    steps = {
+        c.component['uuid']: str(i) for i, c in enumerate(unique_create_events)
+    }
+    for i, c in enumerate(unique_create_events):
+        if c.parent:
+            logging.info(f'[{i}]: {c.huuid}: create ~ [{steps[c.parent]}]')
+        else:
+            logging.info(f'[{i}]: {c.huuid}: create')
+
+    logging.info('JOBS EVENTS:')
+    steps = {j.job_id: str(i) for i, j in enumerate(unique_job_events)}
+
+    def uniquify(x):
+        return sorted(list(set(x)))
+
+    for i, j in enumerate(unique_job_events):
+        if j.dependencies:
+            logging.info(
+                f'[{i}]: {j.huuid}: {j.method} ~ '
+                f'[{",".join(uniquify([steps[d] for d in j.dependencies]))}]'
+            )
+        else:
+            logging.info(f'[{i}]: {j.huuid}: {j.method}')
+
+    events = [
+        *unique_create_events,
+        *unique_job_events,
+        Signal(context=object.uuid, msg='done'),
+    ]
+
+    if not force:
+        if not click.confirm(
+            '\033[1mPlease approve this deployment plan.\033[0m',
+            default=True,
+        ):
+            return object
+    db.cluster.queue.publish(events=events)
+    return object
+
+
+def _apply(
+    db,
+    object: 'Component',
+    parent: t.Optional[str] = None,
+    artifacts: t.Optional[t.Dict[str, bytes]] = None,
+    context: t.Optional[str] = None,
+    job_events: t.Sequence['Job'] = (),
+):
+    job_events = list(job_events)
+
+    object.db = db
+    existing_versions = db.show(object.type_id, object.identifier)
+    already_exists = (
+        isinstance(object.version, int) and object.version in existing_versions
+    )
+    if already_exists:
+        _update_component(object, parent=parent)
+        return [], []
+
+    assert hasattr(object, 'identifier')
+    assert hasattr(object, 'version')
+
+    if object.version is None:
+        if existing_versions:
+            object.version = max(existing_versions) + 1
+        else:
+            object.version = 0
+
+    if object.get_triggers('apply') == ['set_status']:
+        object.status = Status.ready
+
+    serialized = object.dict().encode(leaves_to_keep=(Component,))
+
+    for k, v in serialized[KEY_BUILDS].items():
+        # TODO this is from the `@component` decorator.
+        # Can be handled with a single @leaf decorator around a function
+        # or a class
+        if isinstance(v, Component) and hasattr(v, 'inline') and v.inline:
+            r = dict(v.dict())
+            del r['identifier']
+            serialized[KEY_BUILDS][k] = r
+
+    children = [
+        v for v in serialized[KEY_BUILDS].values() if isinstance(v, Component)
+    ]
+    create_events, j = _add_child_components(
+        db=db,
+        components=children,
+        parent=object,
+        job_events=job_events,
+        context=context,
+    )
+    job_events += j
+    if children:
+        serialized = _change_component_reference_prefix(serialized)
+
+    serialized = db._save_artifact(object.uuid, serialized)
+    if artifacts:
+        for file_id, bytes in artifacts.items():
+            db.artifact_store.put_bytes(bytes, file_id)
+
+    assert context is not None
+    event = Create(
+        context=context,
+        component=serialized,
+        parent=parent,
+    )
+    create_events.append(event)
+
+    job_events += object.create_jobs(
+        event_type='apply', jobs=job_events, context=context
+    )
+    return create_events, job_events
+    
+
+def _change_component_reference_prefix(serialized):
+    """Replace '?' to '&' in the serialized object."""
+    references = {}
+    for reference in list(serialized[KEY_BUILDS].keys()):
+        if isinstance(serialized[KEY_BUILDS][reference], Component):
+            comp = serialized[KEY_BUILDS][reference]
+            serialized[KEY_BUILDS].pop(reference)
+            references[reference] = (
+                comp.type_id + ':' + comp.identifier + ':' + comp.uuid
+            )
+
+    # Only replace component references
+    if not references:
+        return
+
+    def replace_function(value):
+        # Change value if it is a string and starts with '?'
+        # and the value is in references
+        # ?:xxx: -> &:xxx:
+        if (
+            isinstance(value, str)
+            and value.startswith('?')
+            and value[1:] in references
+        ):
+            return '&:component:' + references[value[1:]]
+        return value
+
+    serialized = recursive_update(serialized, replace_function)
+    return serialized
+    
+
+def _add_child_components(db, components, parent, job_events, context):
+    # TODO this is a bit of a mess
+    # it handles the situation in `Stack` when
+    # the components should be added in a certain order
+    G = networkx.DiGraph()
+    lookup = {(c.type_id, c.identifier): c for c in components}
+    for k in lookup:
+        G.add_node(k)
+        for d in lookup[k].get_children_refs():  # dependencies:
+            if d[:2] in lookup:
+                G.add_edge(d, lookup[k].id_tuple)
+
+    nodes = networkx.topological_sort(G)
+    create_events = []
+    job_events = []
+    for n in nodes:
+        c, j = _apply(
+            db=db, object=lookup[n], parent=parent.uuid, job_events=job_events, context=context
+        )
+        create_events += c
+        job_events += j
+    return create_events, job_events
+    
+
+def _update_component(object, parent: t.Optional[str] = None):
+    # TODO add update logic here to check changed attributes
+    logging.debug(
+        f'{object.type_id},{object.identifier} already exists - doing nothing'
+    )
+    return []

--- a/superduper/base/datalayer.py
+++ b/superduper/base/datalayer.py
@@ -621,9 +621,6 @@ class Datalayer:
                 c = Document.decode(info, db=self)
                 c.db = self
 
-        # if c.version is None:
-        #     import pdb; pdb.set_trace()
-
         if c.cache:
             logging.info(f'Adding {c.huuid} to cache')
             self.cluster.cache.put(c)

--- a/superduper/base/datalayer.py
+++ b/superduper/base/datalayer.py
@@ -15,7 +15,7 @@ from superduper.backends.base.compute import ComputeBackend
 from superduper.backends.base.data_backend import BaseDataBackend
 from superduper.backends.base.metadata import MetaDataStore
 from superduper.backends.base.query import Query
-from superduper.base import exceptions
+from superduper.base import apply, exceptions
 from superduper.base.config import Config
 from superduper.base.constant import KEY_BUILDS
 from superduper.base.cursor import SuperDuperCursor
@@ -464,87 +464,11 @@ class Datalayer:
         :param wait: Wait for apply events.
         :return: Tuple containing the added object(s) and the original object(s).
         """
-        if force is None:
-            force = self.cfg.force_apply
-
-        if not isinstance(object, Component):
-            raise ValueError('Only components can be applied')
-
-        # This populates the component with data fetched
-        # from `db` if necessary
-        # We need pre as well as post-create, since the order
-        # between parents and children are reversed in each
-        # sometimes parents might need to grab things from children
-        # and vice-versa
-        object.pre_create(self)
-
-        # context allows us to track the origin of the component creation
-        create_events, job_events = self._apply(
+        return apply.apply(
+            db=self,
             object=object,
-            context=object.uuid,
-            job_events=[],
+            force=force,
         )
-        # this flags that the context is not needed anymore
-        if not create_events:
-            return object
-
-        # TODO for some reason the events get created multiple times
-        # we need to fix that to prevent inefficiencies
-        unique_create_ids = []
-        unique_create_events = []
-        for e in create_events:
-            if e.component['uuid'] not in unique_create_ids:
-                unique_create_ids.append(e.component['uuid'])
-                unique_create_events.append(e)
-
-        unique_job_ids = []
-        unique_job_events = []
-        for e in job_events:
-            if e.job_id not in unique_job_ids:
-                unique_job_ids.append(e.job_id)
-                unique_job_events.append(e)
-
-        logging.info('Here are the CREATION EVENTS:')
-        steps = {
-            c.component['uuid']: str(i) for i, c in enumerate(unique_create_events)
-        }
-        for i, c in enumerate(unique_create_events):
-            if c.parent:
-                logging.info(f'[{i}]: {c.huuid}: create ~ [{steps[c.parent]}]')
-            else:
-                logging.info(f'[{i}]: {c.huuid}: create')
-
-        logging.info('JOBS EVENTS:')
-        steps = {j.job_id: str(i) for i, j in enumerate(unique_job_events)}
-
-        def uniquify(x):
-            return sorted(list(set(x)))
-
-        for i, j in enumerate(unique_job_events):
-            if j.dependencies:
-                logging.info(
-                    f'[{i}]: {j.huuid}: {j.method} ~ '
-                    f'[{",".join(uniquify([steps[d] for d in j.dependencies]))}]'
-                )
-            else:
-                logging.info(f'[{i}]: {j.huuid}: {j.method}')
-
-        events = [
-            *unique_create_events,
-            *unique_job_events,
-            Signal(context=object.uuid, msg='done'),
-        ]
-
-        if not force:
-            if not click.confirm(
-                '\033[1mPlease approve this deployment plan.\033[0m',
-                default=True,
-            ):
-                return object
-        self.cluster.queue.publish(events=events)
-        if wait:
-            self._wait_on_events(unique_create_events)
-        return object
 
     def _wait_on_events(self, events):
         remaining = len(events)
@@ -703,139 +627,6 @@ class Datalayer:
             self.cluster.cache.put(c)
         return c
 
-    def _add_child_components(self, components, parent, job_events, context):
-        # TODO this is a bit of a mess
-        # it handles the situation in `Stack` when
-        # the components should be added in a certain order
-        G = networkx.DiGraph()
-        lookup = {(c.type_id, c.identifier): c for c in components}
-        for k in lookup:
-            G.add_node(k)
-            for d in lookup[k].get_children_refs():  # dependencies:
-                if d[:2] in lookup:
-                    G.add_edge(d, lookup[k].id_tuple)
-
-        nodes = networkx.topological_sort(G)
-        create_events = []
-        job_events = []
-        for n in nodes:
-            c, j = self._apply(
-                lookup[n], parent=parent.uuid, job_events=job_events, context=context
-            )
-            create_events += c
-            job_events += j
-        return create_events, job_events
-
-    def _update_component(self, object, parent: t.Optional[str] = None):
-        # TODO add update logic here to check changed attributes
-        s.logging.debug(
-            f'{object.type_id},{object.identifier} already exists - doing nothing'
-        )
-        return []
-
-    def _apply(
-        self,
-        object: Component,
-        parent: t.Optional[str] = None,
-        artifacts: t.Optional[t.Dict[str, bytes]] = None,
-        context: t.Optional[str] = None,
-        job_events: t.Sequence['Job'] = (),
-    ):
-        job_events = list(job_events)
-
-        object.db = self
-        existing_versions = self.show(object.type_id, object.identifier)
-        already_exists = (
-            isinstance(object.version, int) and object.version in existing_versions
-        )
-        if already_exists:
-            self._update_component(object, parent=parent)
-            return [], []
-
-        assert hasattr(object, 'identifier')
-        assert hasattr(object, 'version')
-
-        if object.version is None:
-            if existing_versions:
-                object.version = max(existing_versions) + 1
-            else:
-                object.version = 0
-
-        if object.get_triggers('apply') == ['set_status']:
-            object.status = Status.ready
-
-        serialized = object.dict().encode(leaves_to_keep=(Component,))
-
-        for k, v in serialized[KEY_BUILDS].items():
-            # TODO this is from the `@component` decorator.
-            # Can be handled with a single @leaf decorator around a function
-            # or a class
-            if isinstance(v, Component) and hasattr(v, 'inline') and v.inline:
-                r = dict(v.dict())
-                del r['identifier']
-                serialized[KEY_BUILDS][k] = r
-
-        children = [
-            v for v in serialized[KEY_BUILDS].values() if isinstance(v, Component)
-        ]
-        create_events, j = self._add_child_components(
-            children,
-            parent=object,
-            job_events=job_events,
-            context=context,
-        )
-        job_events += j
-        if children:
-            serialized = self._change_component_reference_prefix(serialized)
-
-        serialized = self._save_artifact(object.uuid, serialized)
-        if artifacts:
-            for file_id, bytes in artifacts.items():
-                self.artifact_store.put_bytes(bytes, file_id)
-
-        assert context is not None
-        event = Create(
-            context=context,
-            component=serialized,
-            parent=parent,
-        )
-        create_events.append(event)
-
-        job_events += object.create_jobs(
-            event_type='apply', jobs=job_events, context=context
-        )
-        return create_events, job_events
-
-    def _change_component_reference_prefix(self, serialized):
-        """Replace '?' to '&' in the serialized object."""
-        references = {}
-        for reference in list(serialized[KEY_BUILDS].keys()):
-            if isinstance(serialized[KEY_BUILDS][reference], Component):
-                comp = serialized[KEY_BUILDS][reference]
-                serialized[KEY_BUILDS].pop(reference)
-                references[reference] = (
-                    comp.type_id + ':' + comp.identifier + ':' + comp.uuid
-                )
-
-        # Only replace component references
-        if not references:
-            return
-
-        def replace_function(value):
-            # Change value if it is a string and starts with '?'
-            # and the value is in references
-            # ?:xxx: -> &:xxx:
-            if (
-                isinstance(value, str)
-                and value.startswith('?')
-                and value[1:] in references
-            ):
-                return '&:component:' + references[value[1:]]
-            return value
-
-        serialized = recursive_update(serialized, replace_function)
-        return serialized
-
     def _remove_component_version(
         self,
         type_id: str,
@@ -929,7 +720,7 @@ class Datalayer:
                 self.metadata.delete_parent_child(old_uuid, child.uuid)
 
         if children:
-            serialized = self._change_component_reference_prefix(serialized)
+            serialized = apply._change_component_reference_prefix(serialized)
 
         self._delete_artifacts(object.uuid, info)
 

--- a/superduper/base/datalayer.py
+++ b/superduper/base/datalayer.py
@@ -27,10 +27,6 @@ from superduper.misc.colors import Colors
 from superduper.misc.download import download_from_one
 from superduper.misc.retry import db_retry
 
-if t.TYPE_CHECKING:
-    pass
-
-
 DBResult = t.Any
 TaskGraph = t.Any
 

--- a/superduper/base/document.py
+++ b/superduper/base/document.py
@@ -186,7 +186,7 @@ class Document(MongoStyleDict):
                 out = []
                 for x in r:
                     out.append(_map(x))
-                return type(out)(out)
+                return type(r)(out)
             if isinstance(r, type_):
                 return fn(r)
             return r

--- a/superduper/base/event.py
+++ b/superduper/base/event.py
@@ -142,7 +142,6 @@ class Create(Event):
         )
 
 
-
 @dc.dataclass(kw_only=True)
 class Update(Event):
     """
@@ -174,7 +173,6 @@ class Update(Event):
             f'{self.component["identifier"]}:'
             f'{self.component["uuid"]}'
         )
-
 
 
 @dc.dataclass(kw_only=True)

--- a/superduper/base/leaf.py
+++ b/superduper/base/leaf.py
@@ -37,7 +37,8 @@ def import_item(
         object = getattr(module, cls)
 
     try:
-        return object(**dict, db=db)
+        out = object(**dict, db=db)
+        return out
     except TypeError as e:
         if 'got an unexpected keyword argument' in str(e):
             if callable(object) and not inspect.isclass(object):
@@ -136,15 +137,6 @@ class Leaf(metaclass=LeafMeta):
     identifier: str
     db: dc.InitVar[t.Optional['Datalayer']] = None
     uuid: str = dc.field(default_factory=build_uuid)
-
-    def __eq__(self, value: 'Leaf'):
-        assert isinstance(value, type(self))
-        for k in dc.fields(self):
-            if k in self.metadata:
-                continue
-            if not getattr(self, k) == getattr(value, k):
-                return False
-        return True
 
     def _get_metadata(self):
         return {}

--- a/superduper/base/leaf.py
+++ b/superduper/base/leaf.py
@@ -137,6 +137,15 @@ class Leaf(metaclass=LeafMeta):
     db: dc.InitVar[t.Optional['Datalayer']] = None
     uuid: str = dc.field(default_factory=build_uuid)
 
+    def __eq__(self, value: 'Leaf'):
+        assert isinstance(value, type(self))
+        for k in dc.fields(self):
+            if k in self.metadata:
+                continue
+            if not getattr(self, k) == getattr(value, k):
+                return False
+        return True
+
     def _get_metadata(self):
         return {}
 

--- a/superduper/base/leaf.py
+++ b/superduper/base/leaf.py
@@ -147,6 +147,7 @@ class Leaf(metaclass=LeafMeta):
 
     def __post_init__(self, db: t.Optional['Datalayer'] = None):
         self.db = db
+        self.inline = False
 
     @property
     def leaves(self):

--- a/superduper/components/application.py
+++ b/superduper/components/application.py
@@ -23,6 +23,8 @@ class Application(Component):
                  i.e. streamlit, gradio, etc
     """
 
+    breaks: t.ClassVar[t.Sequence[str]] = ('components',)
+
     literals: t.ClassVar[t.Sequence[str]] = ("template",)
     type_id: t.ClassVar[str] = "application"
     components: t.Sequence[Component]

--- a/superduper/components/application.py
+++ b/superduper/components/application.py
@@ -36,6 +36,7 @@ class Application(Component):
         self._sort_components_and_set_upstream()
 
     def _sort_components_and_set_upstream(self):
+        logging.info('Resorting components based on topological order.')
         G = networkx.DiGraph()
         lookup = {c.huuid: c for c in self.components}
         for k in lookup:
@@ -52,6 +53,7 @@ class Application(Component):
             lookup[e[1]].upstream.append(lookup[e[0]])
 
         nodes = networkx.topological_sort(G)
+        logging.info(f'New order of components: {nodes}')
         components = [lookup[n] for n in nodes]
         self.components = components
 

--- a/superduper/components/cdc.py
+++ b/superduper/components/cdc.py
@@ -20,6 +20,10 @@ class CDC(Component):
     type_id: t.ClassVar[str] = 'cdc'
     cdc_table: str
 
+    def handle_update_or_same(self, other):
+        super().handle_update_or_same(other)
+        other.cdc_table = self.cdc_table
+
     def declare_component(self, cluster):
         """Declare the component to the cluster.
 
@@ -28,6 +32,9 @@ class CDC(Component):
         super().declare_component(cluster)
         self.db.cluster.queue.put(self)
         self.db.cluster.cdc.put(self)
+
+    def _get_metadata(self):
+        return {**super()._get_metadata(), 'cdc_table': self.cdc_table}
 
     @property
     def dependencies(self):

--- a/superduper/components/component.py
+++ b/superduper/components/component.py
@@ -149,13 +149,6 @@ class Component(Leaf, metaclass=ComponentMeta):
     cache: t.Optional[bool] = True
     status: t.Optional[Status] = None
 
-    def __eq__(self, value: Component):
-        assert isinstance(value, type(self))
-        for k in dc.fields(self):
-            if not getattr(self, k) == getattr(value, k):
-                return False
-        return True
-
     @property
     def huuid(self):
         """Return a human-readable uuid."""
@@ -214,6 +207,7 @@ class Component(Leaf, metaclass=ComponentMeta):
         """Get all the child components of the component."""
         return self.get_children(deep=False)
 
+    # TODO do we still need this?
     def _job_dependencies(self) -> t.Sequence[str]:
         """List all job ids of component-children."""
         refs = self.get_children_refs(deep=False)
@@ -268,7 +262,7 @@ class Component(Leaf, metaclass=ComponentMeta):
         if requires:
             triggers = [
                 t for t in triggers
-                if getattr(self, t).requires in requires
+                if set(getattr(self, t).requires).intersection(requires)
             ]
         return triggers
 
@@ -470,6 +464,7 @@ class Component(Leaf, metaclass=ComponentMeta):
         metadata = {
             'type_id': self.type_id,
             'version': self.version,
+            'status': self.status,
         }
         return metadata
 

--- a/superduper/components/component.py
+++ b/superduper/components/component.py
@@ -132,6 +132,7 @@ class Component(Leaf, metaclass=ComponentMeta):
     :param status: What part of the lifecycle the component is in.
     """
 
+    breaks: t.ClassVar[t.Sequence] = ()
     triggers: t.ClassVar[t.List] = []
     type_id: t.ClassVar[str] = 'component'
     # TODO is this used for anything?

--- a/superduper/components/datatype.py
+++ b/superduper/components/datatype.py
@@ -230,9 +230,9 @@ class DataType(Component):
         """Check if the encodable is an artifact."""
         return self.encodable_cls.artifact
 
-    def dict(self, metadata: bool = True, defaults: bool = True):
+    def dict(self, metadata: bool = True, defaults: bool = True, refs: bool = False):
         """Get the dictionary representation of the object."""
-        r = super().dict(metadata=metadata, defaults=defaults)
+        r = super().dict(metadata=metadata, defaults=defaults, refs=refs)
         if hasattr(self.bytes_encoding, 'value'):
             r['bytes_encoding'] = str(self.bytes_encoding.value)  # type: ignore[union-attr]
         return r

--- a/superduper/components/listener.py
+++ b/superduper/components/listener.py
@@ -247,23 +247,6 @@ class Listener(CDC):
         """Get reference to outputs of listener model."""
         return f'{CFG.output_prefix}{self.predict_id}'
 
-    # TODO remove
-    @property
-    def outputs_key(self):
-        """Model outputs key."""
-        logging.warn(
-            (
-                "listener.outputs_key is deprecated and will be removed"
-                "in a future release. Please use listener.outputs instead."
-            )
-        )
-        return self.outputs
-
-    @property
-    def outputs_select(self):
-        """Get select statement for outputs."""
-        return self.db[self.select.table].select().outputs(self.predict_id)
-
     @property
     def dependencies(self):
         """Listener model dependencies."""

--- a/superduper/components/listener.py
+++ b/superduper/components/listener.py
@@ -36,6 +36,7 @@ class Listener(CDC):
     """
 
     type_id: t.ClassVar[str] = 'listener'
+    breaks: t.ClassVar[t.Sequence[str]] = ('model', 'key', 'select')
 
     key: ModelInputType
     model: Model
@@ -45,6 +46,11 @@ class Listener(CDC):
     output_table: t.Optional[Table] = None
     flatten: bool = False
 
+    def _get_metadata(self):
+        """Get metadata of the component."""
+        metadata = super()._get_metadata()
+        return {**metadata, 'output_table': self.output_table}
+
     def __post_init__(self, db, artifacts):
         if not self.cdc_table and self.select:
             self.cdc_table = self.select.table
@@ -52,9 +58,15 @@ class Listener(CDC):
 
         return super().__post_init__(db, artifacts)
 
-    def dict(self, metadata: bool = True, defaults: bool = True) -> t.Dict:
+    def handle_update_or_same(self, other):
+        super().handle_update_or_same(other)
+        other.output_table = self.output_table
+
+    def dict(
+        self, metadata: bool = True, defaults: bool = True, refs: bool = False
+    ) -> t.Dict:
         """Convert to dictionary."""
-        out = super().dict(metadata=metadata, defaults=defaults)
+        out = super().dict(metadata=metadata, defaults=defaults, refs=refs)
         if not metadata:
             try:
                 del out['output_table']

--- a/superduper/components/model.py
+++ b/superduper/components/model.py
@@ -232,7 +232,7 @@ class Trainer(Component):
 
 
 class Validation(Component):
-    """component which represents Validation definition.
+    """Component which represents Validation definition.
 
     :param metrics: List of metrics for validation
     :param key: Model input type key
@@ -881,7 +881,7 @@ class Model(Component, metaclass=ModelMeta):
                 metrics=self.validation.metrics,
             )
             self.metric_values[f'{dataset.identifier}/{dataset.version}'] = results
-        self.db.replace(self, upsert=True)
+        self.db.replace(self)
 
     def _create_datasets(self, X, db, select):
         train_dataset = self._create_dataset(
@@ -1242,6 +1242,7 @@ class SequentialModel(Model):
 
     :param models: A list of models to use
     """
+
     breaks: t.ClassVar[t.Sequence] = ('models',)
 
     models: t.List[Model]
@@ -1302,6 +1303,7 @@ class ModelRouter(Model):
     :param models: A dictionary of models to use
     :param model: The model to use
     """
+
     breaks: t.ClassVar[t.Sequence] = ('models',)
     models: t.Dict[str, Model]
     model: str
@@ -1342,6 +1344,7 @@ class RAGModel(Model):
     :param key: Key to use for get text out of documents.
     :param llm: Language model to use.
     """
+
     breaks: t.ClassVar[t.Sequence] = ('llm', 'prompt_template')
 
     prompt_template: str

--- a/superduper/components/model.py
+++ b/superduper/components/model.py
@@ -375,6 +375,7 @@ class Model(Component, metaclass=ModelMeta):
     :param deploy: Creates a standalone class instance on compute cluster.
     """
 
+    breaks: t.ClassVar[t.Sequence] = ('trainer',)
     type_id: t.ClassVar[str] = 'model'
     signature: Signature = '*args,**kwargs'
     datatype: EncoderArg = None
@@ -1028,6 +1029,7 @@ class ObjectModel(Model):
 
     """
 
+    breaks: t.ClassVar[t.Sequence] = ('object', 'trainer')
     _artifacts: t.ClassVar[t.Sequence[t.Tuple[str, 'DataType']]] = (
         ('object', dill_lazy),
     )
@@ -1240,6 +1242,7 @@ class SequentialModel(Model):
 
     :param models: A list of models to use
     """
+    breaks: t.ClassVar[t.Sequence] = ('models',)
 
     models: t.List[Model]
 
@@ -1299,7 +1302,7 @@ class ModelRouter(Model):
     :param models: A dictionary of models to use
     :param model: The model to use
     """
-
+    breaks: t.ClassVar[t.Sequence] = ('models',)
     models: t.Dict[str, Model]
     model: str
 
@@ -1339,6 +1342,7 @@ class RAGModel(Model):
     :param key: Key to use for get text out of documents.
     :param llm: Language model to use.
     """
+    breaks: t.ClassVar[t.Sequence] = ('llm', 'prompt_template')
 
     prompt_template: str
     signature: str = 'singleton'

--- a/superduper/components/vector_index.py
+++ b/superduper/components/vector_index.py
@@ -110,6 +110,7 @@ class VectorIndex(CDC):
     """
 
     type_id: t.ClassVar[str] = 'vector_index'
+    breaks: t.ClassVar[t.Sequence[str]] = ('indexing_listener',)
 
     indexing_listener: Listener
     compatible_listener: t.Optional[Listener] = None
@@ -121,6 +122,11 @@ class VectorIndex(CDC):
         self.cdc_table = self.cdc_table or self.indexing_listener.outputs
         return super().__post_init__(db, artifacts)
 
+    def refresh(self):
+        if self.cdc_table.startswith('_outputs'):
+            self.cdc_table = self.indexing_listener.outputs
+
+    # TODO why this?
     def __hash__(self):
         return hash((self.type_id, self.identifier))
 

--- a/superduper/components/vector_index.py
+++ b/superduper/components/vector_index.py
@@ -123,7 +123,7 @@ class VectorIndex(CDC):
         return super().__post_init__(db, artifacts)
 
     def refresh(self):
-        if self.cdc_table.startswith('_outputs'):
+        if self.cdc_table.startswith(CFG.output_prefix):
             self.cdc_table = self.indexing_listener.outputs
 
     # TODO why this?

--- a/superduper/ext/numpy/encoder.py
+++ b/superduper/ext/numpy/encoder.py
@@ -91,4 +91,4 @@ class NumpyDataTypeFactory(DataTypeFactory):
         It's used for registering the auto schema.
         :param data: The numpy array.
         """
-        return array(dtype=str(data.dtype), shape=data.shape)
+        return array(dtype=str(data.dtype), shape=list(data.shape))

--- a/superduper/misc/annotations.py
+++ b/superduper/misc/annotations.py
@@ -161,6 +161,7 @@ def build_importable(*, db=None, importable=None):
     return getattr(importlib.import_module(module), attr)
 
 
+# TODO remove @component() -> @component
 def component(*schema: t.Dict):
     """Decorator for creating a component.
 

--- a/superduper/misc/annotations.py
+++ b/superduper/misc/annotations.py
@@ -180,7 +180,9 @@ def component(*schema: t.Dict):
 
             assert isinstance(out, Component)
 
-            def to_dict(metadata: bool = True, defaults: bool = True):
+            def to_dict(
+                metadata: bool = True, defaults: bool = True, uuid: bool = True
+            ):
                 path = f'{f.__module__}.{f.__name__}'
                 from superduper.base.document import Document
 
@@ -198,6 +200,9 @@ def component(*schema: t.Dict):
                     for k in out.metadata:
                         if k in r:
                             del r[k]
+
+                if not uuid and 'uuid' in r:
+                    del r['uuid']
 
                 if 'identifier' not in r:
                     r['identifier'] = out.identifier

--- a/test/integration/usecase/test_graceful_update.py
+++ b/test/integration/usecase/test_graceful_update.py
@@ -1,0 +1,80 @@
+import random
+import typing as t
+
+import numpy
+
+from superduper import Listener, Model, VectorIndex, logging
+from superduper.base.annotations import trigger
+from superduper.base.datalayer import Datalayer
+from superduper.components.model import Validation
+
+
+class MyModel(Model):
+    breaks: t.ClassVar = ('a', 'b')
+
+    a: int = 1
+    b: int = 2
+    signature: str = 'singleton'
+
+    def predict(self, x):
+        return numpy.array([x + self.a * self.b + 2 for _ in range(20)])
+
+    @trigger('apply', requires='validation')
+    def validate_in_db(self):
+        out = self.validation.validate(self)
+        self.metric_values = [out]
+        self.db.replace(self)
+
+
+class MyValidation(Validation):
+    def validate(self, model):
+        logging.info('Running my-validation')
+        return 0.1
+
+
+def test(db: Datalayer):
+    db.cfg.auto_schema = True
+
+    db['docs'].insert([{'x': random.randrange(10)} for _ in range(10)]).execute()
+
+    def build_vi(**kwargs):
+        model = MyModel('my-model', example=1, **kwargs)
+
+        listener = Listener(
+            'my-listener',
+            model=model,
+            select=db['docs'].select(),
+            key='x',
+        )
+
+        return VectorIndex(
+            'my-vector-index',
+            indexing_listener=listener,
+        )
+
+    db.apply(build_vi())
+    db.apply(build_vi())
+
+    assert db.show('vector_index', 'my-vector-index') == [0]
+    assert db.show('listener', 'my-listener') == [0]
+    assert db.show('model', 'my-model') == [0]
+
+    component = build_vi()
+    component.indexing_listener.select = db['other'].select()
+
+    db.apply(component)
+
+    assert db.show('listener', 'my-listener') == [0, 1]
+    assert db.show('vector_index', 'my-vector-index') == [0, 1]
+
+    component.indexing_listener.model.validation = MyValidation(
+        'test-validate', key='x', datasets=[], metrics=[]
+    )
+
+    db.apply(component)
+
+    assert db.show('model', 'my-model') == [0]
+
+    m = db.load('model', 'my-model')
+
+    assert m.metric_values == [0.1]

--- a/test/integration/usecase/test_output_prefix.py
+++ b/test/integration/usecase/test_output_prefix.py
@@ -31,17 +31,17 @@ def test_output_prefix(db):
         for t in expect_tables:
             assert any(k.startswith(t) for k in tables)
 
-        outputs_a = list(listener_a.outputs_select.execute())
+        outputs_a = db[listener_a.outputs].select().tolist()
         assert len(outputs_a) == 6
         for r in outputs_a:
             assert any(k.startswith("sddb_outputs_a") for k in r)
 
-        outputs_b = list(listener_b.outputs_select.execute())
+        outputs_b = db[listener_b.outputs].select().tolist()
         assert len(outputs_b) == 6
         for r in outputs_b:
             assert any(k.startswith("sddb_outputs_b") for k in r)
 
-        outputs_c = list(listener_c.outputs_select.execute())
+        outputs_c = db[listener_c.outputs].select().tolist()
         assert len(outputs_c) == 6
         for r in outputs_c:
             assert any(k.startswith("sddb_outputs_c") for k in r)

--- a/test/unittest/backends/local/test_artifacts.py
+++ b/test/unittest/backends/local/test_artifacts.py
@@ -113,13 +113,13 @@ def test_duplicate_artifact(capfd, db, artifact_store: FileSystemArtifactStore):
         return x
 
     test_component = TestComponentBytes(function=my_func, identifier="test")
-    db.add(test_component)
+    db.apply(test_component)
     test_component_loaded = db.load("TestComponent", "test")
     test_component_loaded.init()
 
     # This should use skip the artifact since it exists
-    test_component = TestComponentBytes(function=my_func, identifier="test")
-    db.add(test_component)
+    test_component = TestComponentBytes(function=my_func, identifier="another")
+    db.apply(test_component)
     out, _ = capfd.readouterr()
 
     # assert "Artifact with file_id" in out

--- a/test/unittest/base/test_apply.py
+++ b/test/unittest/base/test_apply.py
@@ -174,7 +174,6 @@ def test_break_nested(db: Datalayer):
 
     assert db.show('my', 'test') == [0]
     assert db.show('my', 'sub') == [0, 1]
-
     assert db.load('my', 'sub').b == 4
 
 

--- a/test/unittest/base/test_apply.py
+++ b/test/unittest/base/test_apply.py
@@ -183,4 +183,26 @@ def test_break_nested(db: Datalayer):
 
 
 def test_job_on_update(db: Datalayer):
-    ...
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+    )
+
+    db.apply(c)
+
+    assert db.show('my', 'test') == [0]
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+        sub=MyValidator('valid', target=2)
+    )
+
+    db.apply(c)
+
+    reload = db.load('my', 'test')
+
+    assert reload.validate_results is not None

--- a/test/unittest/base/test_apply.py
+++ b/test/unittest/base/test_apply.py
@@ -1,6 +1,15 @@
-import pytest
 import typing as t
 from superduper import Component
+from superduper.base.annotations import trigger
+from superduper.base.datalayer import Datalayer
+
+
+class MyValidator(Component):
+    target: int
+
+    def run(self, parent):
+        return float(parent.b * parent.c > self.target)
+
 
 class MyComponent(Component):
     type_id: t.ClassVar[str] = 'my'
@@ -8,24 +17,34 @@ class MyComponent(Component):
 
     a: str
     b: int
+    c: float = 0.5
     sub: Component | None = None
+    validate_results: bool | None = None
 
+    @trigger('apply', requires='sub')
+    def validate_in_db(self):
+        if isinstance(self.sub, MyValidator):
+            self.validate_results = self.sub.run(self)
+            self.db.replace(self)
+        return self.validate_results
 
-def test_simple_apply(db):
+def test_simple_apply(db: Datalayer):
 
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
 
     assert db.show('my') == ['test']
+    assert db.show('my', 'test') == [0]
 
 
-@pytest.mark.skip
-def test_skip_same(db):
+def test_skip_same(db: Datalayer):
 
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
+
+    assert db.show()
 
     c = MyComponent('test', a='value', b=1)
 
@@ -37,8 +56,7 @@ def test_skip_same(db):
     assert db.show('my', 'test') == [0]
 
 
-@pytest.mark.skip
-def test_update_component_version(db):
+def test_update_component_version(db: Datalayer):
 
     c = MyComponent('test', a='value', b=1)
 
@@ -61,7 +79,7 @@ def test_update_component_version(db):
     assert reload.a == 'new-value'
 
 
-def test_break_version(db):
+def test_break_version(db: Datalayer):
 
     c = MyComponent('test', a='value', b=1)
 
@@ -84,8 +102,7 @@ def test_break_version(db):
     assert reload.b == 2
 
 
-@pytest.mark.skip
-def test_update_nested(db):
+def test_update_nested(db: Datalayer):
 
     c = MyComponent(
         'test',
@@ -100,7 +117,7 @@ def test_update_nested(db):
 
     db.apply(c)
 
-    assert db.show('my') == ['test', 'sub']
+    assert set(db.show('my')) == {'test', 'sub'}
 
     c = MyComponent(
         'test',
@@ -113,14 +130,20 @@ def test_update_nested(db):
         )
     )
 
+    # Neither the child or the parent
+    # is broken by updating sub.a
+    # that means we don't get a new
+    # version
     db.apply(c)
 
     assert db.show('my', 'test') == [0]
     assert db.show('my', 'sub') == [0]
 
+    # Nonetheless the child is updated
+    assert db.load('my', 'sub').a == 'new-sub-value'
 
-@pytest.mark.skip
-def test_break_nested(db):
+
+def test_break_nested(db: Datalayer):
 
     c = MyComponent(
         'test',
@@ -135,7 +158,7 @@ def test_break_nested(db):
 
     db.apply(c)
 
-    assert db.show('my') == ['test', 'sub']
+    assert set(db.show('my')) == {'test', 'sub'}
 
     c = MyComponent(
         'test',
@@ -155,3 +178,9 @@ def test_break_nested(db):
 
     assert db.show('my', 'test') == [0]
     assert db.show('my', 'sub') == [0, 1]
+
+    assert db.load('my', 'sub').b == 4
+
+
+def test_job_on_update(db: Datalayer):
+    ...

--- a/test/unittest/base/test_apply.py
+++ b/test/unittest/base/test_apply.py
@@ -1,0 +1,157 @@
+import pytest
+import typing as t
+from superduper import Component
+
+class MyComponent(Component):
+    type_id: t.ClassVar[str] = 'my'
+    breaks: t.ClassVar[t.Sequence[str]] = ('b',)
+
+    a: str
+    b: int
+    sub: Component | None = None
+
+
+def test_simple_apply(db):
+
+    c = MyComponent('test', a='value', b=1)
+
+    db.apply(c)
+
+    assert db.show('my') == ['test']
+
+
+@pytest.mark.skip
+def test_skip_same(db):
+
+    c = MyComponent('test', a='value', b=1)
+
+    db.apply(c)
+
+    c = MyComponent('test', a='value', b=1)
+
+    db.apply(c)
+
+    # applying same component again,
+    # means nothing happens
+    # no computations and no updates
+    assert db.show('my', 'test') == [0]
+
+
+@pytest.mark.skip
+def test_update_component_version(db):
+
+    c = MyComponent('test', a='value', b=1)
+
+    db.apply(c)
+
+    reload = db.load('my', 'test')
+
+    assert reload.a == 'value'
+
+    c = MyComponent('test', a='new-value', b=1)
+
+    db.apply(c)
+
+    # creates only one version but
+    # updates it
+    assert db.show('my', 'test') == [0]
+
+    reload = db.load('my', 'test')
+
+    assert reload.a == 'new-value'
+
+
+def test_break_version(db):
+
+    c = MyComponent('test', a='value', b=1)
+
+    db.apply(c)
+
+    reload = db.load('my', 'test')
+
+    assert reload.b == 1
+
+    c = MyComponent('test', a='value', b=2)
+
+    db.apply(c)
+
+    # creates only one version but
+    # updates it
+    assert db.show('my', 'test') == [0, 1]
+
+    reload = db.load('my', 'test')
+
+    assert reload.b == 2
+
+
+@pytest.mark.skip
+def test_update_nested(db):
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+        sub=MyComponent(
+            'sub',
+            a='sub-value',
+            b=3,
+        )
+    )
+
+    db.apply(c)
+
+    assert db.show('my') == ['test', 'sub']
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+        sub=MyComponent(
+            'sub',
+            a='new-sub-value',
+            b=3,
+        )
+    )
+
+    db.apply(c)
+
+    assert db.show('my', 'test') == [0]
+    assert db.show('my', 'sub') == [0]
+
+
+@pytest.mark.skip
+def test_break_nested(db):
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+        sub=MyComponent(
+            'sub',
+            a='sub-value',
+            b=3,
+        )
+    )
+
+    db.apply(c)
+
+    assert db.show('my') == ['test', 'sub']
+
+    c = MyComponent(
+        'test',
+        a='value',
+        b=2,
+        sub=MyComponent(
+            'sub',
+            a='sub-value',
+            b=4,
+        )
+    )
+
+    # re-applying this component should break 
+    # the child, however the parent isn't
+    # broken by self.sub, so is only updated
+    db.apply(c)
+
+    assert db.show('my', 'test') == [0]
+    assert db.show('my', 'sub') == [0, 1]

--- a/test/unittest/base/test_apply.py
+++ b/test/unittest/base/test_apply.py
@@ -1,4 +1,5 @@
 import typing as t
+
 from superduper import Component
 from superduper.base.annotations import trigger
 from superduper.base.datalayer import Datalayer
@@ -28,8 +29,8 @@ class MyComponent(Component):
             self.db.replace(self)
         return self.validate_results
 
-def test_simple_apply(db: Datalayer):
 
+def test_simple_apply(db: Datalayer):
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
@@ -39,7 +40,6 @@ def test_simple_apply(db: Datalayer):
 
 
 def test_skip_same(db: Datalayer):
-
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
@@ -57,7 +57,6 @@ def test_skip_same(db: Datalayer):
 
 
 def test_update_component_version(db: Datalayer):
-
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
@@ -80,7 +79,6 @@ def test_update_component_version(db: Datalayer):
 
 
 def test_break_version(db: Datalayer):
-
     c = MyComponent('test', a='value', b=1)
 
     db.apply(c)
@@ -103,7 +101,6 @@ def test_break_version(db: Datalayer):
 
 
 def test_update_nested(db: Datalayer):
-
     c = MyComponent(
         'test',
         a='value',
@@ -112,7 +109,7 @@ def test_update_nested(db: Datalayer):
             'sub',
             a='sub-value',
             b=3,
-        )
+        ),
     )
 
     db.apply(c)
@@ -127,7 +124,7 @@ def test_update_nested(db: Datalayer):
             'sub',
             a='new-sub-value',
             b=3,
-        )
+        ),
     )
 
     # Neither the child or the parent
@@ -144,7 +141,6 @@ def test_update_nested(db: Datalayer):
 
 
 def test_break_nested(db: Datalayer):
-
     c = MyComponent(
         'test',
         a='value',
@@ -153,7 +149,7 @@ def test_break_nested(db: Datalayer):
             'sub',
             a='sub-value',
             b=3,
-        )
+        ),
     )
 
     db.apply(c)
@@ -168,10 +164,10 @@ def test_break_nested(db: Datalayer):
             'sub',
             a='sub-value',
             b=4,
-        )
+        ),
     )
 
-    # re-applying this component should break 
+    # re-applying this component should break
     # the child, however the parent isn't
     # broken by self.sub, so is only updated
     db.apply(c)
@@ -183,7 +179,6 @@ def test_break_nested(db: Datalayer):
 
 
 def test_job_on_update(db: Datalayer):
-
     c = MyComponent(
         'test',
         a='value',
@@ -194,12 +189,7 @@ def test_job_on_update(db: Datalayer):
 
     assert db.show('my', 'test') == [0]
 
-    c = MyComponent(
-        'test',
-        a='value',
-        b=2,
-        sub=MyValidator('valid', target=2)
-    )
+    c = MyComponent('test', a='value', b=2, sub=MyValidator('valid', target=2))
 
     db.apply(c)
 

--- a/test/unittest/base/test_document.py
+++ b/test/unittest/base/test_document.py
@@ -261,3 +261,20 @@ def test_encode_same_identifier():
     assert listener.identifier == "a"
     assert listener.model.identifier == "a"
     assert listener.model.datatype.identifier == "a"
+
+
+def test_diff():
+
+    r1 = Document({
+        'a': 1,
+        'b': 2
+    })
+
+    r2 = Document({
+        'a': 1,
+        'b': 3
+    })
+
+    diff = r1.diff(r2)
+
+    print(diff)

--- a/test/unittest/base/test_document.py
+++ b/test/unittest/base/test_document.py
@@ -264,16 +264,9 @@ def test_encode_same_identifier():
 
 
 def test_diff():
+    r1 = Document({'a': 1, 'b': 2})
 
-    r1 = Document({
-        'a': 1,
-        'b': 2
-    })
-
-    r2 = Document({
-        'a': 1,
-        'b': 3
-    })
+    r2 = Document({'a': 1, 'b': 3})
 
     diff = r1.diff(r2)
 

--- a/test/unittest/base/test_document.py
+++ b/test/unittest/base/test_document.py
@@ -270,4 +270,4 @@ def test_diff():
 
     diff = r1.diff(r2)
 
-    print(diff)
+    assert set(diff.keys()) == {'b'}

--- a/test/unittest/component/test_application.py
+++ b/test/unittest/component/test_application.py
@@ -4,7 +4,7 @@ from pprint import pprint
 import numpy as np
 import pytest
 
-from superduper import ObjectModel, Schema, superduper
+from superduper import Application, ObjectModel, Schema, superduper
 from superduper.base.document import Document
 from superduper.components.datatype import pickle_encoder
 from superduper.components.table import Table
@@ -93,3 +93,18 @@ def test_wrap_as_application_from_db(db: "Datalayer"):
     assert get_listener_output(listener1) == 2
     assert get_listener_output(listener2) == 4
     assert np.allclose(get_listener_output(listener3), data["z"] * 3)
+
+
+def test_sort_components(db):
+    m = ObjectModel('test', object=lambda x: x + 1)
+
+    l1 = m.to_listener(key='x', select=db['docs'].select(), identifier='l1')
+    l2 = m.to_listener(
+        key=l1.outputs,
+        select=db[l1.outputs].select(),
+        identifier='l2',
+    )
+
+    app = Application('test-app', components=[l2, l1])
+
+    assert app.components[0].identifier == 'l1'

--- a/test/unittest/component/test_listener.py
+++ b/test/unittest/component/test_listener.py
@@ -77,7 +77,7 @@ def test_listener_chaining(db):
 
     listener2 = Listener(
         model=m2,
-        select=listener1.outputs_select,
+        select=db[listener1.outputs].select(),
         key=listener1.outputs,
         identifier='listener2',
     )
@@ -85,7 +85,7 @@ def test_listener_chaining(db):
     db.apply(listener2)
 
     def check_listener_output(listener, output_n):
-        docs = list(db.execute(listener.outputs_select))
+        docs = db[listener.outputs].select().tolist()
         assert len(docs) == output_n
         assert all([listener.outputs in r for r in docs])
 
@@ -134,7 +134,7 @@ def test_create_output_dest(db, data, flatten):
 
     db.apply(listener1)
 
-    doc = list(db.execute(listener1.outputs_select))[0]
+    doc = db[listener1.outputs].select().tolist()[0]
     result = Document(doc.unpack())[listener1.outputs]
     assert isinstance(result, type(data))
     if isinstance(data, np.ndarray):
@@ -176,7 +176,7 @@ def test_listener_cleanup(db, data):
     )
 
     db.add(listener1)
-    doc = list(db.execute(listener1.outputs_select))[0]
+    doc = db[listener1.outputs].select().tolist()[0]
     result = Document(doc.unpack())[listener1.outputs]
     assert isinstance(result, type(data))
     if isinstance(data, np.ndarray):

--- a/test/unittest/component/test_template.py
+++ b/test/unittest/component/test_template.py
@@ -58,7 +58,7 @@ def test_basic_template(db):
     primary_id = db['documents'].primary_id
     r = db['documents'].select(primary_id, 'y').outputs(listener.predict_id).execute()
     r = Document(list(r)[0].unpack())
-    assert r[listener.outputs_key] == r['y'] + 2
+    assert r[listener.outputs] == r['y'] + 2
 
 
 def test_template_export(db):
@@ -109,7 +109,7 @@ def test_template_export(db):
             .execute()
         )
         r = Document(list(r)[0].unpack())
-        assert r[listener.outputs_key] == r['y'] + 2
+        assert r[listener.outputs] == r['y'] + 2
 
 
 def test_from_template(db):

--- a/test/unittest/jobs/test_task_workflow.py
+++ b/test/unittest/jobs/test_task_workflow.py
@@ -45,17 +45,17 @@ def test_downstream_task_workflows_are_triggered(db, data, flatten):
     )
 
     downstream_listener = downstream_model.to_listener(
-        key=upstream_listener.outputs_key,
-        select=upstream_listener.outputs_select,
+        key=upstream_listener.outputs,
+        select=db[upstream_listener.outputs].select(),
         identifier="downstream",
     )
 
     db.apply(downstream_listener)
 
-    outputs1 = list(upstream_listener.outputs_select.execute())
+    outputs1 = db[upstream_listener.outputs].select().tolist()
     outputs1 = [r[upstream_listener.outputs] for r in outputs1]
 
-    outputs2 = list(downstream_listener.outputs_select.execute())
+    outputs2 = db[downstream_listener.outputs].select().tolist()
     outputs2 = [r[downstream_listener.outputs] for r in outputs2]
 
     assert len(outputs1) == 1 if not flatten else 10
@@ -68,13 +68,13 @@ def test_downstream_task_workflows_are_triggered(db, data, flatten):
 
     # Check that the listeners are triggered when data is inserted later
     outputs1 = [
-        Document(d.unpack())[upstream_listener.outputs_key]
-        for d in db.execute(upstream_listener.outputs_select)
+        Document(d.unpack())[upstream_listener.outputs]
+        for d in db[upstream_listener.outputs].select().execute()
     ]
 
     outputs2 = [
-        Document(d.unpack())[downstream_listener.outputs_key]
-        for d in db.execute(downstream_listener.outputs_select)
+        Document(d.unpack())[downstream_listener.outputs]
+        for d in db[downstream_listener.outputs].select().execute()
     ]
 
     assert len(outputs1) == 2 if not flatten else 20


### PR DESCRIPTION
This PR solves #2211 introducing updates as part of the `db.apply` API.

- Versioning is judged by the attributes of `Component`
- `Component` instances with changed attributes in `Component.breaks` create new versions ("breaking changes")
- `Component` instances with other changed attributes ("non-breaking changes") lead to an edit of an existing component
- Nested `Component` instances are supported - jobs are only deployed for `Component` instances which have changed data relevant to jobs, using `@trigger('apply', requires=...)`; `requires` says which changes trigger the job.