### PR TITLE
Add select missing ids in mongodb plugin

### DIFF
--- a/plugins/mongodb/plugin_test/test_query.py
+++ b/plugins/mongodb/plugin_test/test_query.py
@@ -72,6 +72,7 @@ def test_select_missing_outputs(db):
         )
     )
     select = MongoQuery(table='documents').find({}, {'_id': 1})
+    select.db = db
     modified_select = select.select_ids_of_missing_outputs('x::test_model_output::0::0')
     out = list(db.execute(modified_select))
     assert len(out) == (len(docs) - len(ids))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description
fix https://github.com/superduper-io/superduper/issues/2631

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
