### PR TITLE
Deprecate signature as argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed defaults / behaviours
 
-...
+- No need to add `.signature` to `Model` implementations
 
 #### New Features & Functionality
 
@@ -20,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Bug Fixes
 
 - Fix the random silent failure bug when ibis creates tables.
-
-...
 
 ## [0.5.0](https://github.com/superduper-io/superduper/compare/0.5.0...0.4.0])    (2024-Nov-02)
 
@@ -36,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor secrets loading method.
 - Add db.load in db wait
 - Add model component cleanup
+- Deprecate `signature` as parameter and auto-infer from `.predict`
 
 #### New Features & Functionality
 

--- a/superduper/components/graph.py
+++ b/superduper/components/graph.py
@@ -197,7 +197,6 @@ class DocumentInput(Model):
 
     spec: t.Union[str, t.List[str]]
     identifier: str = '_input'
-    signature: Signature = 'singleton'
 
     def __post_init__(self, db, example):
         super().__post_init__(db, example)
@@ -232,12 +231,11 @@ class Graph(Model):
     :param edges: Graph edges list.
     :param input: Graph root node.
     :param outputs: Graph output nodes.
-    :param signature: Graph signature.
 
     Example:
     -------
     >> g = Graph(
-    >>   identifier='simple-graph', input=model1, outputs=[model2], signature='*args'
+    >>   identifier='simple-graph', input=model1, outputs=[model2],
     >> )
     >> g.connect(model1, model2)
     >> assert g.predict(1) == [(4, 2)]
@@ -253,7 +251,6 @@ class Graph(Model):
     )
     input: Model
     outputs: t.List[t.Union[str, Model]] = dc.field(default_factory=list)
-    signature: Signature = '*args,**kwargs'
 
     def __post_init__(self, db, example):
         self.G = nx.DiGraph()
@@ -261,7 +258,7 @@ class Graph(Model):
         self.version = 0
         self._db = None
 
-        self.signature = self.input.signature
+        self._signature = self.input.signature
         if isinstance(self.outputs, list):
             self.output_identifiers = [
                 o.identifier if isinstance(o, Model) else o for o in self.outputs

--- a/superduper/rest/build.py
+++ b/superduper/rest/build.py
@@ -280,10 +280,9 @@ def build_rest_app(app: SuperDuperApp):
     @app.add('/db/show_template', method='get')
     def db_show_template(
         identifier: str,
-        type_id: str = 'template',
         db: 'Datalayer' = DatalayerDependency(),
     ):
-        template: Template = db.load(type_id=type_id, identifier=identifier)
+        template: Template = db.load(type_id='template', identifier=identifier)
         return template.form_template
 
     @app.add('/db/edit', method='get')
@@ -293,7 +292,7 @@ def build_rest_app(app: SuperDuperApp):
         db: 'Datalayer' = DatalayerDependency(),
     ):
         component = db.load(type_id, identifier)
-        template = db.load('template', component.build_template)
+        template: Template = db.load('template', component.build_template)
         form = template.form_template
         form['_variables'] = component.build_variables
         return form

--- a/test/unittest/base/test_datalayer.py
+++ b/test/unittest/base/test_datalayer.py
@@ -475,7 +475,6 @@ def test_replace(db: Datalayer):
         object=lambda x: x + 1,
         identifier='m',
         datatype=DataType(identifier='base'),
-        signature='singleton',
     )
     model.version = 0
     db.apply(model)
@@ -484,7 +483,8 @@ def test_replace(db: Datalayer):
     assert db.load('model', 'm').predict(1) == 2
 
     new_model = ObjectModel(
-        object=lambda x: x + 2, identifier='m', signature='singleton'
+        object=lambda x: x + 2,
+        identifier='m',
     )
     new_model.version = 0
     db.replace(new_model)
@@ -496,7 +496,8 @@ def test_replace(db: Datalayer):
 
     # replace the last version of the model
     new_model = ObjectModel(
-        object=lambda x: x + 3, identifier='m', signature='singleton'
+        object=lambda x: x + 3,
+        identifier='m',
     )
     new_model.version = 0
     db.replace(new_model)

--- a/test/unittest/component/test_graph.py
+++ b/test/unittest/component/test_graph.py
@@ -11,7 +11,7 @@ def model1(db):
     def model_object(x):
         return x + 1
 
-    model = ObjectModel(identifier='m1', object=model_object, signature='singleton')
+    model = ObjectModel(identifier='m1', object=model_object)
     yield model
 
 
@@ -53,13 +53,17 @@ def model3(db):
 
 def test_simple_graph(model1, model2):
     g = Graph(
-        identifier='simple-graph', input=model1, outputs=model2, signature='*args'
+        identifier='simple-graph',
+        input=model1,
+        outputs=model2,
     )
     g.connect(model1, model2)
     assert g.predict(1) == (4, 2)
 
     g = Graph(
-        identifier='simple-graph', input=model1, outputs=model2, signature='*args'
+        identifier='simple-graph',
+        input=model1,
+        outputs=model2,
     )
     g.connect(model1, model2)
     assert g.predict_batches([1, 2, 3]) == [(4, 2), (5, 3), (6, 4)]
@@ -70,7 +74,6 @@ def test_graph_output_indexing(model2_multi_dict, model2, model1):
         identifier='simple-graph',
         input=model1,
         outputs=[model2],
-        signature='**kwargs',
     )
     g.connect(model1, model2_multi_dict, on=(None, 'x'))
     g.connect(model2_multi_dict, model2, on=('x', 'x'))

--- a/test/unittest/component/test_plugin.py
+++ b/test/unittest/component/test_plugin.py
@@ -10,7 +10,7 @@ PYTHON_CODE = """
 from superduper import Model
 
 class PModel(Model):
-    def predict(self) -> int:
+    def predict(self, X) -> int:
         return "{plugin_type}"
 """
 
@@ -82,7 +82,7 @@ def test_module(tmpdir):
     from p_module import PModel
 
     model = PModel("test")
-    assert model.predict() == "module"
+    assert model.predict(2) == "module"
 
 
 def test_package(tmpdir):
@@ -96,7 +96,7 @@ def test_package(tmpdir):
     from p_package.p_package import PModel
 
     model = PModel("test")
-    assert model.predict() == "package"
+    assert model.predict(2) == "package"
 
 
 def test_directory(tmpdir):
@@ -111,7 +111,7 @@ def test_directory(tmpdir):
 
     model = PModel("test")
 
-    assert model.predict() == "directory"
+    assert model.predict(2) == "directory"
 
 
 def test_repeated_loading(tmpdir):
@@ -151,7 +151,7 @@ def test_import(tmpdir):
     from p_import.p_import import PModel
 
     model = PModel("test")
-    assert model.predict() == "import"
+    assert model.predict(2) == "import"
 
 
 def test_apply(db, tmpdir):

--- a/test/unittest/ext/test_vanilla.py
+++ b/test/unittest/ext/test_vanilla.py
@@ -21,7 +21,7 @@ def test_function_predict():
 
 
 def test_function_predict_batches():
-    function = ObjectModel(object=lambda x: x, identifier='test', signature='singleton')
+    function = ObjectModel(object=lambda x: x, identifier='test')
     assert function.predict_batches([1, 1]) == [1, 1]
 
 


### PR DESCRIPTION
This PR disables the need to add `signature='*args,**kwargs'` or similar to a model.