### PR TITLE
Add a standalone flag in Streamlit to mark the page as independent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a meta-datatype `Vector` to handle different databackend requirements
 - Support `<var:template_staged_file>` in Template to enable apps to use files/folders included in the template
 - Add Data Component for storing data directly in the template
+- Add a standalone flag in Streamlit to mark the page as independent.
 
 #### Bug Fixes
 

--- a/superduper/components/streamlit.py
+++ b/superduper/components/streamlit.py
@@ -10,12 +10,14 @@ class Streamlit(Component):
     :param demo_func: Callable which builds the demo.
     :param demo_kwargs: key-word arguments to the `demo_func`
     :param default: Set to `True` if this is to be the frontpage.
+    :param is_standalone: Set to `True` if this is a standalone page.
     """
 
     type_id: t.ClassVar[str] = 'streamlit'
     demo_func: t.Callable
     demo_kwargs: t.Dict = dc.field(default_factory=dict)
     default: bool = False
+    is_standalone: bool = False
 
     @property
     def page(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

If this is your first time, please have a look at the contribution guidelines here:

https://github.com/superduperdb/superduperdb/blob/main/CONTRIBUTING.md
-->


## Description

<!-- A brief description of the changes in this pull request -->


## Related Issues

<!-- Link to any related github issues here.

Examples:
   Update serialization (fix #1234)
   Move data to location (see #3456)

You might want to read
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
