### PR TITLE
Potential fix for code scanning alert no. 33: Expression injection in Actions

### DIFF
--- a/.github/workflows/release_plugins.yaml
+++ b/.github/workflows/release_plugins.yaml
@@ -15,8 +15,10 @@ jobs:
 
       - name: Extract plugin names from commit message
         id: set-matrix
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          commit_message="${{ github.event.head_commit.message }}"
+          commit_message="$COMMIT_MESSAGE"
           echo "Commit message: $commit_message"
           plugin_names=$(echo "$commit_message" | grep -oP '\[PLUGINS\] Bump Version \[\K[^\]]+')
           


### PR DESCRIPTION
Potential fix for [https://github.com/superduper-io/superduper/security/code-scanning/33](https://github.com/superduper-io/superduper/security/code-scanning/33)

To fix the problem, we need to avoid using the commit message directly in the `run` block. Instead, we should set the commit message to an environment variable and use shell syntax to read the environment variable. This will prevent any potential injection.

- Set the commit message to an environment variable.
- Use the environment variable in the shell script to avoid direct interpolation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
