### PR TITLE
Potential fix for code scanning alert no. 10: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
               
         # Artifacts located in artifact/
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
 
       - name: Install wheel
         run: python -m pip install artifact/*.whl


### PR DESCRIPTION
Potential fix for [https://github.com/superduper-io/superduper/security/code-scanning/10](https://github.com/superduper-io/superduper/security/code-scanning/10)

To fix the problem, we need to update the version of the `actions/download-artifact` action from v3 to 4.1.7. This change ensures that the workflow uses a version of the action that does not have known vulnerabilities, thereby improving the security of the workflow.

- Locate the line in the `.github/workflows/release.yaml` file where the `actions/download-artifact` action is used.
- Update the version from `v3` to `v4.1.7`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
