### PR TITLE
Move inspect.signature calls out of comprehensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # superduper.io Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. 
 
 The format is inspired by (but not strictly follows) [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/superduper/base/annotations.py
+++ b/superduper/base/annotations.py
@@ -52,11 +52,8 @@ def trigger(
                 )
             else:
                 self.setup()
-                kwargs = {
-                    k: v
-                    for k, v in kwargs.items()
-                    if k in inspect.signature(f).parameters
-                }
+                signature_params = inspect.signature(f).parameters
+                kwargs = {k: v for k, v in kwargs.items() if k in signature_params}
                 return f(self, **kwargs)
 
         decorated.events = event_types

--- a/superduper/base/base.py
+++ b/superduper/base/base.py
@@ -184,12 +184,9 @@ class Base(metaclass=BaseMeta):
     @classmethod
     def from_dict(cls, r: t.Dict, db: t.Optional['Datalayer'] = None):
         if hasattr(cls, '_alternative_init'):
+            signature_params = inspect.signature(cls._alternative_init).parameters
             return cls._alternative_init(
-                **{
-                    k: v
-                    for k, v in r.items()
-                    if k in inspect.signature(cls._alternative_init).parameters
-                },
+                **{k: v for k, v in r.items() if k in signature_params},
                 db=db,
             )
         try:
@@ -197,11 +194,8 @@ class Base(metaclass=BaseMeta):
             return out
         except TypeError as e:
             if 'got an unexpected keyword argument' in str(e):
-                init_params = {
-                    k: v
-                    for k, v in r.items()
-                    if k in inspect.signature(cls.__init__).parameters
-                }
+                signature_params = inspect.signature(cls.__init__).parameters
+                init_params = {k: v for k, v in r.items() if k in signature_params}
                 post_init_params = {
                     k: v for k, v in r.items() if k in cls.set_post_init
                 }
@@ -377,11 +371,8 @@ class Base(metaclass=BaseMeta):
 
         :param r: Encoded data.
         """
-        modified = {
-            k: v
-            for k, v in r.items()
-            if k in inspect.signature(cls.__init__).parameters
-        }
+        signature_params = inspect.signature(cls.__init__).parameters
+        modified = {k: v for k, v in r.items() if k in signature_params}
         return cls(**modified)
 
     def setup(self, db=None):

--- a/superduper/base/datatype.py
+++ b/superduper/base/datatype.py
@@ -216,10 +216,9 @@ def _decode_base(r, builds, db: t.Optional['Datalayer'] = None):
     dict_ = {k: v for k, v in r.items() if k != '_path'}
 
     if inspect.isfunction(cls):
+        signature_params = inspect.signature(cls).parameters
         out = cls(
-            **{
-                k: v for k, v in dict_.items() if k in inspect.signature(cls).parameters
-            },
+            **{k: v for k, v in dict_.items() if k in signature_params},
             db=db,
         )
     else:


### PR DESCRIPTION
## Description

The code contained a few instances of the following pattern:
```
[... for ... in ... if ... in inspect.signature(f).parameters]
```

Each call of `inspect.signature(...)` takes some time, which adds up to a noticeable delay due to the repeated execution in the comprehension loop.
The PR moves the calls of inspect.signature out of the comprehensions.